### PR TITLE
Add square bracket constructor to Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,18 @@ Structures:
 
 Algorithms:
 
-- [ ] Graph algorithms: search, traversal, colouring
-- [ ] Approximation algorithms
-- [ ] Optimization algorithms
+- Graph algorithms:
+  - Deterministic algorithms:
+    - Breadth-first search
+    - Depth-first search
+    - Shortest path
+    - Minimum spanning tree
+    - Maximum flow
+    - More TBD
+  - Aproximation algorithms
+    - Graph Colouring
+    - Traveling salesman
+
 
 ## Usage
 

--- a/lib/math/discrete/graph.rb
+++ b/lib/math/discrete/graph.rb
@@ -11,6 +11,34 @@ class Math::Discrete::Graph
   attr_reader :vertex_set, :edge_set, :properties
   alias_method :node_set, :vertex_set
 
+  def self.[](vertex_set_or_labels = Set[], edge_set_or_labels = Set[])
+    unless vertex_set_or_labels.is_a?(Set) || vertex_set_or_labels.is_a?(Array)
+      raise Math::Discrete::TypeError, 'vertices must be of type Set or Array'
+    end
+
+    unless edge_set_or_labels.is_a?(Set) || edge_set_or_labels.is_a?(Array)
+      raise Math::Discrete::TypeError, 'edges must be of type Set or Array'
+    end
+
+    vertex_types = vertex_set_or_labels.map(&:class).uniq
+    edge_types = edge_set_or_labels.map(&:class).uniq
+
+    raise Math::Discrete::TypeError, 'all vertices must be of same type' unless vertex_types.size <= 1
+    raise Math::Discrete::TypeError, 'all edges must be of same type' unless edge_types.size <= 1
+
+    if vertex_types == [Vertex] && edge_types == [Edge]
+      build_from_sets(
+        vertex_set: Set[*vertex_set_or_labels],
+        edge_set_or_labels: Set[*edge_set_or_labels]
+      )
+    else
+      build_from_labels(
+        vertex_labels: Set[*vertex_set_or_labels],
+        edge_labels: Set[*edge_set_or_labels]
+      )
+    end
+  end
+
   def self.build(directed: true)
     new directed: directed
   end

--- a/lib/math/discrete/graph.rb
+++ b/lib/math/discrete/graph.rb
@@ -11,30 +11,27 @@ class Math::Discrete::Graph
   attr_reader :vertex_set, :edge_set, :properties
   alias_method :node_set, :vertex_set
 
-  def self.[](vertex_set_or_labels = Set[], edge_set_or_labels = Set[])
-    unless vertex_set_or_labels.is_a?(Set) || vertex_set_or_labels.is_a?(Array)
+  def self.[](vertices_or_labels = Set[], edges_or_labels = Set[])
+    unless vertices_or_labels.is_a?(Set) || vertices_or_labels.is_a?(Array)
       raise Math::Discrete::TypeError, 'vertices must be of type Set or Array'
     end
 
-    unless edge_set_or_labels.is_a?(Set) || edge_set_or_labels.is_a?(Array)
+    unless edges_or_labels.is_a?(Set) || edges_or_labels.is_a?(Array)
       raise Math::Discrete::TypeError, 'edges must be of type Set or Array'
     end
 
-    vertex_types = vertex_set_or_labels.map(&:class).uniq
-    edge_types = edge_set_or_labels.map(&:class).uniq
-
-    raise Math::Discrete::TypeError, 'all vertices must be of same type' unless vertex_types.size <= 1
-    raise Math::Discrete::TypeError, 'all edges must be of same type' unless edge_types.size <= 1
+    vertex_types = vertices_or_labels.map(&:class).uniq
+    edge_types = edges_or_labels.map(&:class).uniq
 
     if vertex_types == [Vertex] && edge_types == [Edge]
       build_from_sets(
-        vertex_set: Set[*vertex_set_or_labels],
-        edge_set_or_labels: Set[*edge_set_or_labels]
+        vertex_set: Set[*vertices_or_labels],
+        edge_set: Set[*edges_or_labels]
       )
     else
       build_from_labels(
-        vertex_labels: Set[*vertex_set_or_labels],
-        edge_labels: Set[*edge_set_or_labels]
+        vertex_labels: Set[*vertices_or_labels],
+        edge_labels: Set[*edges_or_labels]
       )
     end
   end

--- a/lib/math/discrete/graph/edge.rb
+++ b/lib/math/discrete/graph/edge.rb
@@ -24,9 +24,11 @@ class Math::Discrete::Graph::Edge
 
   def ==(other_edge)
     return false unless directed? == other_edge.directed?
-
     return from == other_edge.from && to == other_edge.to if directed?
-    from == other_edge.from && to == other_edge.to || from == other_edge.to && to == other_edge.from
+    return true if from == other_edge.from && to == other_edge.to
+    return true if from == other_edge.to && to == other_edge.from
+
+    false
   end
 
   def directed?

--- a/lib/math/discrete/graph/predicates.rb
+++ b/lib/math/discrete/graph/predicates.rb
@@ -1,7 +1,5 @@
 module Math::Discrete::Graph::Predicates
   Math::Discrete::Graph::Properties.each do |property|
-    define_method("#{property.adjective}?") do
-      self.satisfies? property
-    end
+    define_method("#{property.adjective}?") { self.satisfies? property }
   end
 end

--- a/spec/graph/graph_spec.rb
+++ b/spec/graph/graph_spec.rb
@@ -5,19 +5,54 @@ describe Math::Discrete::Graph do
   let(:undirected_graph) { Graph.build directed: false }
   let(:labels) { Set['A', 'B'] }
 
-  describe '::build, ::build directed: true' do
-    it 'creates a directed graph with an empty vertex set and edge set' do
-      expect(directed_graph.vertex_set).to be_empty
-      expect(directed_graph.edge_set).to be_empty
-      expect(directed_graph).to be_directed
+  describe '::[]' do
+    let(:vertex_set) { Graph::Vertex.build_from_labels 'A', 'B', 'C' }
+    let(:edge_set) do
+      Set[
+        Edge::Directed.build(from: vertex_set.entries[0], to: vertex_set.entries[1]),
+        Edge::Directed.build(from: vertex_set.entries[1], to: vertex_set.entries[0]),
+        Edge::Directed.build(from: vertex_set.entries[1], to: vertex_set.entries[2]),
+        Edge::Directed.build(from: vertex_set.entries[2], to: vertex_set.entries[1])
+      ]
+    end
+    let(:graph_from_sets) { Graph[vertex_set, edge_set] }
+    let(:graph_from_labels) { Graph[[1, 2, 3], [[1, 2], [2, 3], [3, 1], [1, 3]]] }
+
+    it 'raises a TypeError if the given vertex set or label set is not a Set or an Array' do
+      expect { Graph['vertices', Set[]] }.to raise_error Math::Discrete::TypeError
+    end
+
+    it 'raises a TypeError if the given edge set or label set is not a Set or an Array' do
+      expect { Graph[Set[], 'edges'] }.to raise_error Math::Discrete::TypeError
+    end
+
+    it 'builds a graph from the given vertex set and edge set' do
+      expect(graph_from_sets).to be_a Graph
+      expect(graph_from_sets.vertex_set).to eq vertex_set
+      expect(graph_from_sets.edge_set).to eq edge_set
+    end
+
+    it 'builds a graph from the given vertex label set and edge label set' do
+      expect(graph_from_labels).to be_a Graph
+      expect(graph_from_labels.vertex_labels).to eq Set[1, 2, 3]
     end
   end
 
-  describe '::build directed: false' do
-    it 'creates an undirected graph with an empty vertex set and edge set' do
-      expect(undirected_graph.vertex_set).to be_empty
-      expect(undirected_graph.edge_set).to be_empty
-      expect(undirected_graph).not_to be_directed
+  describe '::build' do
+    describe 'directed: true' do
+      it 'creates a directed graph with an empty vertex set and edge set' do
+        expect(directed_graph.vertex_set).to be_empty
+        expect(directed_graph.edge_set).to be_empty
+        expect(directed_graph).to be_directed
+      end
+    end
+
+    describe 'directed: false' do
+      it 'creates an undirected graph with an empty vertex set and edge set' do
+        expect(undirected_graph.vertex_set).to be_empty
+        expect(undirected_graph.edge_set).to be_empty
+        expect(undirected_graph).not_to be_directed
+      end
     end
   end
 


### PR DESCRIPTION
__Goal__
Add a constructor for `Graph` using square brackets. It is polymorphic and allows to use either directly sets or arrays of `Vertex` and `Edge` objects, or labels directly.

```ruby
Graph[]
<=> Graph.build_from_labels vertex_labels: Set[], edge_labels: Set[]

Graph[[1,2,3], [[1,2],[2,3],[3,1]]]
<=> Graph.build_from_labels vertex_labels: Set[1,2,3], edge_labels: Set[[1,2],[2,3],[3,1]]

Graph[Set[1,2,3], Set[[1,2],[2,3],[3,1]]]
<=> Graph.build_from_labels vertex_labels: Set[1,2,3], edge_labels: Set[[1,2],[2,3],[3,1]]
```