### PR TITLE
Add graph paths

### DIFF
--- a/lib/discrete.rb
+++ b/lib/discrete.rb
@@ -4,14 +4,8 @@ require 'set'
 module Math::Discrete
   class TypeError < StandardError; end
 
-  class Property; end
-
   class Graph; end
-  module Graph::Properties; end
   module Graph::Predicates; end
-  module Graph::Algorithms; end
-  class Graph::Vertex; end
-  class Graph::Edge; end
 end
 
 require 'math/discrete/version'
@@ -22,7 +16,7 @@ require 'math/discrete/graph'
 require 'math/discrete/graph/predicates'
 require 'math/discrete/graph/vertex'
 require 'math/discrete/graph/edge'
-
+require 'math/discrete/graph/path'
 
 Graph = Math::Discrete::Graph
 Vertex = Graph::Vertex

--- a/lib/discrete.rb
+++ b/lib/discrete.rb
@@ -18,6 +18,7 @@ require 'math/discrete/graph/vertex'
 require 'math/discrete/graph/edge'
 require 'math/discrete/graph/path'
 
+TypeError = Math::Discrete::TypeError
 Graph = Math::Discrete::Graph
 Vertex = Graph::Vertex
 Node = Vertex

--- a/lib/math/discrete/graph.rb
+++ b/lib/math/discrete/graph.rb
@@ -63,7 +63,7 @@ class Math::Discrete::Graph
       graph
     end
 
-    def build_from_labels(directed: true, vertex_labels: Set[], edge_labels: Set[])
+    def build_from_labels(vertex_labels: Set[], edge_labels: Set[])
       raise TypeError, 'vertex_labels must be of type Set' unless vertex_labels.is_a? Set
       raise TypeError, 'edge_labels must be of type Set' unless edge_labels.is_a? Set
 
@@ -78,11 +78,7 @@ class Math::Discrete::Graph
         raise VertexNotFound, "could not find a vertex with label=#{ label_set.to_a.last }" if to.nil?
         raise TypeError, 'edge weight must be of a Numeric type' unless weight.is_a? Numeric
 
-        if directed
-          Edge::Directed[from, to, weight]
-        else
-          Edge::Undirected[from, to, weight]
-        end
+        Edge::Directed[from, to, weight]
       end
 
       build_from_sets vertex_set: Set[*vertices], edge_set: Set[*edges]

--- a/lib/math/discrete/graph.rb
+++ b/lib/math/discrete/graph.rb
@@ -71,15 +71,17 @@ class Math::Discrete::Graph
 
       edges = edge_labels.map do |label_set|
         from = vertices.find { |vertex| vertex.label == label_set.first }
-        to = vertices.find { |vertex| vertex.label == label_set.to_a.last }
+        to = vertices.find { |vertex| vertex.label == label_set.to_a[1] }
+        weight = label_set.to_a[2] || 1
 
         raise VertexNotFound, "could not find a vertex with label=#{ label_set.first }" if from.nil?
         raise VertexNotFound, "could not find a vertex with label=#{ label_set.to_a.last }" if to.nil?
+        raise TypeError, 'edge weight must be of a Numeric type' unless weight.is_a? Numeric
 
         if directed
-          Edge::Directed[from, to]
+          Edge::Directed[from, to, weight]
         else
-          Edge::Undirected[from, to]
+          Edge::Undirected[from, to, weight]
         end
       end
 
@@ -189,7 +191,7 @@ class Math::Discrete::Graph
   alias_method :node_set, :vertex_set
 
   def vertex_labels
-    vertex_set.map(&:label).to_set
+    @vertex_map.keys.to_set
   end
   alias_method :node_labels, :vertex_labels
 

--- a/lib/math/discrete/graph/algorithms.rb
+++ b/lib/math/discrete/graph/algorithms.rb
@@ -4,7 +4,7 @@ module Math::Discrete::Graph::Algorithms
   def breadth_first_search(root: vertex_set.first)
     return {} if @vertex_map.empty?
 
-    raise Math::Discrete::TypeError, 'root must be of the type Math::Discrete::Graph::Vertex' unless root.is_a? Vertex
+    raise TypeError, 'root must be of the type Math::Discrete::Graph::Vertex' unless root.is_a? Vertex
     raise Graph::VertexNotFound, "could not find vertex with label=#{root.label}" unless vertex_labels.include? root.label
 
 
@@ -32,7 +32,7 @@ module Math::Discrete::Graph::Algorithms
   def depth_first_search(root: vertex_set.first)
     return {} if @vertex_map.empty?
 
-    raise Math::Discrete::TypeError, 'root must be of the type Math::Discrete::Graph::Vertex' unless root.is_a? Vertex
+    raise TypeError, 'root must be of the type Math::Discrete::Graph::Vertex' unless root.is_a? Vertex
     raise Graph::VertexNotFound, "could not find vertex with label=#{root.label}" unless vertex_labels.include? root.label
 
 
@@ -55,5 +55,51 @@ module Math::Discrete::Graph::Algorithms
     end
 
     search_tree
+  end
+
+  def shortest_path_between(source: , target:)
+    raise TypeError, 'source and target must be of type Vertex' unless source.is_a?(Vertex) && target.is_a?(Vertex)
+    raise Graph::VertexNotFound, "could not find vertex with label=#{source.label}" unless vertex_labels.include? source.label
+    raise Graph::VertexNotFound, "could not find vertex with label=#{target.label}" unless vertex_labels.include? target.label
+
+    return Graph::Path[] if source == target
+
+    distance_tree = { source.label => { distance: 0, parent: nil } }
+    priority_queue = Containers::PriorityQueue.new do |a,b|
+      (distance_tree[a][:distance] <=> distance_tree[b][:distance]) == -1
+    end
+
+    vertex_set.each do |vertex|
+      unless vertex == source
+        distance_tree[vertex.label] = {
+          distance: Float::INFINITY,
+          parent: nil
+        }
+      end
+
+      priority_queue.push vertex, vertex.label
+    end
+
+    until priority_queue.empty?
+      vertex = priority_queue.pop
+
+      vertex.adjacent_vertices.each do |neighbour|
+        alt = distance_tree[vertex.label][:distance] + vertex.distance_to(neighbour)
+
+        if alt < distance_tree[neighbour.label][:distance]
+          distance_tree[neighbour.label][:distance] = alt
+          distance_tree[neighbour.label][:parent] = vertex.label
+        end
+      end
+    end
+
+    edges = []
+    current_vertex = target.label
+    until distance_tree[current_vertex][:parent].nil? do
+      edges << find_edge_by_labels!(distance_tree[current_vertex][:parent], current_vertex)
+      current_vertex = distance_tree[current_vertex][:parent]
+    end
+
+    Graph::Path[*edges.reverse]
   end
 end

--- a/lib/math/discrete/graph/algorithms.rb
+++ b/lib/math/discrete/graph/algorithms.rb
@@ -59,8 +59,8 @@ module Math::Discrete::Graph::Algorithms
     search_tree
   end
 
-  def shortest_path_between(source: , target:)
-    raise TypeError, 'source and target must be of type Vertex' unless source.is_a?(Vertex) && target.is_a?(Vertex)
+  def shortest_path_between(source, target)
+    raise TypeError, 'source and target vertices must be of type Vertex' unless source.is_a?(Vertex) && target.is_a?(Vertex)
     raise Graph::VertexNotFound, "could not find vertex with label=#{source.label}" unless vertex_labels.include? source.label
     raise Graph::VertexNotFound, "could not find vertex with label=#{target.label}" unless vertex_labels.include? target.label
 
@@ -92,10 +92,7 @@ module Math::Discrete::Graph::Algorithms
 
     vertex_set.each do |vertex|
       unless vertex == source
-        distance_tree[vertex.label] = {
-          distance: Float::INFINITY,
-          parent: nil
-        }
+        distance_tree[vertex.label] = { distance: Float::INFINITY, parent: nil }
       end
 
       priority_queue.push vertex, vertex.label
@@ -108,8 +105,7 @@ module Math::Discrete::Graph::Algorithms
         alt = distance_tree[vertex.label][:distance] + vertex.distance_to(neighbour)
 
         if alt < distance_tree[neighbour.label][:distance]
-          distance_tree[neighbour.label][:distance] = alt
-          distance_tree[neighbour.label][:parent] = vertex.label
+          distance_tree[neighbour.label] = { distance: alt, parent: vertex.label }
         end
       end
     end
@@ -122,18 +118,16 @@ module Math::Discrete::Graph::Algorithms
 
     vertex_set.each do |vertex|
       unless vertex == source
-        distance_tree[vertex.label] = {
-          distance: Float::INFINITY,
-          parent: nil
-        }
+        distance_tree[vertex.label] = { distance: Float::INFINITY, parent: nil }
       end
     end
 
     (vertex_set.size - 1).times do
       @edge_set.each do |edge|
-        if distance_tree[edge.from.label][:distance] + edge.weight < distance_tree[edge.to.label][:distance]
-          distance_tree[edge.to.label][:distance] = distance_tree[edge.from.label][:distance] + edge.weight
-          distance_tree[edge.to.label][:parent] = edge.from.label
+        alt = distance_tree[edge.from.label][:distance] + edge.weight
+
+        if alt < distance_tree[edge.to.label][:distance]
+          distance_tree[edge.to.label] = { distance: alt, parent: edge.from.label }
         end
       end
     end

--- a/lib/math/discrete/graph/algorithms.rb
+++ b/lib/math/discrete/graph/algorithms.rb
@@ -1,8 +1,8 @@
 require 'algorithms'
 
 module Math::Discrete::Graph::Algorithms
-  def breadth_first_search(root: @vertex_set.first)
-    return {} if @vertex_set.empty?
+  def breadth_first_search(root: vertex_set.first)
+    return {} if @vertex_map.empty?
 
     raise Math::Discrete::TypeError, 'root must be of the type Math::Discrete::Graph::Vertex' unless root.is_a? Vertex
     raise Graph::VertexNotFound, "could not find vertex with label=#{root.label}" unless vertex_labels.include? root.label
@@ -29,8 +29,8 @@ module Math::Discrete::Graph::Algorithms
     search_tree
   end
 
-  def depth_first_search(root: @vertex_set.first)
-    return {} if @vertex_set.empty?
+  def depth_first_search(root: vertex_set.first)
+    return {} if @vertex_map.empty?
 
     raise Math::Discrete::TypeError, 'root must be of the type Math::Discrete::Graph::Vertex' unless root.is_a? Vertex
     raise Graph::VertexNotFound, "could not find vertex with label=#{root.label}" unless vertex_labels.include? root.label

--- a/lib/math/discrete/graph/edge.rb
+++ b/lib/math/discrete/graph/edge.rb
@@ -2,24 +2,54 @@ class Math::Discrete::Graph::Edge
   attr_reader :from, :to
   attr_accessor :weight
 
+  private_class_method :new
+  def initialize(from: , to:, directed: true, weight: 1)
+    raise Math::Discrete::TypeError, 'from must be of type Math::Discrete::Graph::Vertex' unless from.is_a? Vertex
+    raise Math::Discrete::TypeError, 'to must be of type Math::Discrete::Graph::Vertex' unless to.is_a? Vertex
+    raise Math::Discrete::TypeError, 'directed must be of a Boolean type' unless !!directed == directed
+    raise Math::Discrete::TypeError, 'weight must be of a Numeric type' unless weight.is_a? Numeric
+
+    @from = from
+    @to = to
+    @directed = directed
+    @weight = weight
+
+    @from.send :add_adjacent_vertex, @to, weight
+    @to.send :add_adjacent_vertex, @from, weight unless directed
+  end
+
   module Undirected
-    def self.build_between(from, to, weight: 1)
-      Graph::Edge.new directed: false, from: from, to: to, weight: weight
+    def self.[](from, to, weight = 1)
+      Edge.send :new, directed: false, from: from, to: to, weight: weight
     end
   end
 
   module Directed
-    def self.build(from:, to:, weight: 1)
-      Graph::Edge.new directed: true, from: from, to: to, weight: weight
+    def self.[](from, to, weight = 1)
+      Edge.send :new, directed: true, from: from, to: to, weight: weight
+    end
+  end
+
+  module Set
+    module Undirected
+      def self.[](*edges)
+        edges.map { |edge| Edge::Undirected[*edge] }.to_set
+      end
+    end
+
+    module Directed
+      def self.[](*edges)
+        edges.map { |edge| Edge::Directed[*edge] }.to_set
+      end
     end
   end
 
   def labels
-    Set[from.label, to.label]
+    [from.label, to.label].to_set
   end
 
   def vertices
-    Set[from, to]
+    [from, to].to_set
   end
 
   def ==(other_edge)
@@ -37,22 +67,5 @@ class Math::Discrete::Graph::Edge
 
   def weighted?
     @weight != 1
-  end
-
-  private
-
-  def initialize(from: , to:, directed: true, weight: 1)
-    raise Math::Discrete::TypeError, 'from must be of type Math::Discrete::Graph::Vertex' unless from.is_a? Vertex
-    raise Math::Discrete::TypeError, 'to must be of type Math::Discrete::Graph::Vertex' unless to.is_a? Vertex
-    raise Math::Discrete::TypeError, 'directed must be of a Boolean type' unless !!directed == directed
-    raise Math::Discrete::TypeError, 'weight must be of a Numeric type' unless weight.is_a? Numeric
-
-    @from = from
-    @to = to
-    @directed = directed
-    @weight = weight
-
-    @from.send :add_adjacent_vertex, @to
-    @to.send :add_adjacent_vertex, @from unless directed
   end
 end

--- a/lib/math/discrete/graph/edge.rb
+++ b/lib/math/discrete/graph/edge.rb
@@ -4,10 +4,10 @@ class Math::Discrete::Graph::Edge
 
   private_class_method :new
   def initialize(from: , to:, directed: true, weight: 1)
-    raise Math::Discrete::TypeError, 'from must be of type Math::Discrete::Graph::Vertex' unless from.is_a? Vertex
-    raise Math::Discrete::TypeError, 'to must be of type Math::Discrete::Graph::Vertex' unless to.is_a? Vertex
-    raise Math::Discrete::TypeError, 'directed must be of a Boolean type' unless !!directed == directed
-    raise Math::Discrete::TypeError, 'weight must be of a Numeric type' unless weight.is_a? Numeric
+    raise TypeError, 'from must be of type Math::Discrete::Graph::Vertex' unless from.is_a? Vertex
+    raise TypeError, 'to must be of type Math::Discrete::Graph::Vertex' unless to.is_a? Vertex
+    raise TypeError, 'directed must be of a Boolean type' unless !!directed == directed
+    raise TypeError, 'weight must be of a Numeric type' unless weight.is_a? Numeric
 
     @from = from
     @to = to

--- a/lib/math/discrete/graph/edge.rb
+++ b/lib/math/discrete/graph/edge.rb
@@ -18,7 +18,7 @@ class Math::Discrete::Graph::Edge
     Set[from.label, to.label]
   end
 
-  def to_set
+  def vertices
     Set[from, to]
   end
 

--- a/lib/math/discrete/graph/path.rb
+++ b/lib/math/discrete/graph/path.rb
@@ -1,10 +1,15 @@
 class Math::Discrete::Graph::Path
   class InvalidPath < StandardError; end
 
+  private_class_method :new
+  def initialize(edges = Set[])
+    @edges = edges
+  end
+
   def self.[](edges = [])
     raise Math::Discrete::TypeError, 'edges must be an Array' unless edges.is_a? Array
     raise Math::Discrete::Graph::EdgeNotUnique, 'edges must be unique' unless edges.uniq.size == edges.size
-    raise InvalidPath, 'must be a continuous valid path' unless valid_path?(edges)
+    raise InvalidPath, 'must be a valid continuous path' unless valid_path?(edges)
 
     new edges
   end
@@ -36,10 +41,6 @@ class Math::Discrete::Graph::Path
   end
 
   private
-
-  def initialize(edges = Set[])
-    @edges = edges
-  end
 
   def self.valid_path?(edges)
     true

--- a/lib/math/discrete/graph/path.rb
+++ b/lib/math/discrete/graph/path.rb
@@ -6,18 +6,17 @@ class Math::Discrete::Graph::Path
     @edges = edges
   end
 
-  def self.[](edges = [])
-    raise Math::Discrete::TypeError, 'edges must be an Array' unless edges.is_a? Array
+  def self.[](*edges)
     raise Math::Discrete::Graph::EdgeNotUnique, 'edges must be unique' unless edges.uniq.size == edges.size
     raise InvalidPath, 'must be a valid continuous path' unless valid_path?(edges)
 
     new edges
   end
 
-  def cycle?
+  def cyclical?
     return false if @edges.empty?
 
-    labels.first.first == labels.last.last
+    labels.first.first == labels.to_a.last.to_a.last
   end
 
   def labels

--- a/lib/math/discrete/graph/path.rb
+++ b/lib/math/discrete/graph/path.rb
@@ -1,16 +1,17 @@
 class Math::Discrete::Graph::Path
   class InvalidPath < StandardError; end
 
+  attr_reader :edges
+
   private_class_method :new
   def initialize(edges = Set[])
     @edges = edges
   end
 
   def self.[](*edges)
-    raise Math::Discrete::Graph::EdgeNotUnique, 'edges must be unique' unless edges.uniq.size == edges.size
     raise InvalidPath, 'must be a valid continuous path' unless valid_path?(edges)
 
-    new edges
+    new Set[*edges]
   end
 
   def cyclical?
@@ -24,16 +25,9 @@ class Math::Discrete::Graph::Path
   end
 
   def vertices
-    Set[*@edges.flat_map(&:vertices)]
+    Set[*@edges.map(&:vertices).reduce(&:+)]
   end
-
-  def directed?
-    @edges.any? &:directed?
-  end
-
-  def weighted?
-    @edges.any? &:weighted?
-  end
+  alias_method :nodes, :vertices
 
   def length
     @edges.size
@@ -42,6 +36,8 @@ class Math::Discrete::Graph::Path
   private
 
   def self.valid_path?(edges)
-    true
+    edges.each_cons(2).all? do |initial_edge, following_edge|
+      initial_edge.to == following_edge.from
+    end
   end
 end

--- a/lib/math/discrete/graph/path.rb
+++ b/lib/math/discrete/graph/path.rb
@@ -1,0 +1,47 @@
+class Math::Discrete::Graph::Path
+  class InvalidPath < StandardError; end
+
+  def self.[](edges = [])
+    raise Math::Discrete::TypeError, 'edges must be an Array' unless edges.is_a? Array
+    raise Math::Discrete::Graph::EdgeNotUnique, 'edges must be unique' unless edges.uniq.size == edges.size
+    raise InvalidPath, 'must be a continuous valid path' unless valid_path?(edges)
+
+    new edges
+  end
+
+  def cycle?
+    return false if @edges.empty?
+
+    labels.first.first == labels.last.last
+  end
+
+  def labels
+    Set[*@edges.map(&:labels)]
+  end
+
+  def vertices
+    Set[*@edges.flat_map(&:vertices)]
+  end
+
+  def directed?
+    @edges.any? &:directed?
+  end
+
+  def weighted?
+    @edges.any? &:weighted?
+  end
+
+  def length
+    @edges.size
+  end
+
+  private
+
+  def initialize(edges = Set[])
+    @edges = edges
+  end
+
+  def self.valid_path?(edges)
+    true
+  end
+end

--- a/lib/math/discrete/graph/vertex.rb
+++ b/lib/math/discrete/graph/vertex.rb
@@ -39,7 +39,7 @@ class Math::Discrete::Graph::Vertex
 
   private
 
-  def add_adjacent_vertex(vertex, weight)
+  def add_adjacent_vertex(vertex, weight = 1)
     @adjacent_vertices.add vertex
     @edge_weights[vertex.label] = weight
   end

--- a/lib/math/discrete/graph/vertex.rb
+++ b/lib/math/discrete/graph/vertex.rb
@@ -2,18 +2,31 @@ class Math::Discrete::Graph::Vertex
   attr_accessor :label
   attr_reader :adjacent_vertices
 
-  def self.build_from_label(label)
+  private_class_method :new
+  def initialize(label: nil)
+    @label = label
+    @adjacent_vertices = Set[]
+    @edge_weights = {}
+  end
+
+  def self.[](label)
     new label: label
   end
 
-  def self.build_from_labels(*labels)
-    [*labels].map { |label| build_from_label label }.to_set
+  module Set
+    def self.[](*labels)
+      [*labels].map { |label| Vertex[label] }.to_set
+    end
   end
 
   def adjacent_to?(other_vertex)
     raise Math::Discrete::TypeError, 'other_vertex must be of type Math::Discrete::Vertex' unless other_vertex.is_a? Vertex
 
     @adjacent_vertices.include? other_vertex
+  end
+
+  def distance_to(other_vertex)
+    raise Math::Discrete::Graph::VertexNotFound, '' unless adjacent_to
   end
 
   def ==(other_vertex)
@@ -24,16 +37,13 @@ class Math::Discrete::Graph::Vertex
 
   private
 
-  def initialize(label: nil)
-    @label = label
-    @adjacent_vertices = Set[]
-  end
-
-  def add_adjacent_vertex(vertex)
+  def add_adjacent_vertex(vertex, weight)
     @adjacent_vertices.add vertex
+    @edge_weights[vertex.label] = weight
   end
 
   def remove_adjacent_vertex(vertex)
     @adjacent_vertices.delete vertex
+    @edge_weights.delete vertex.label
   end
 end

--- a/lib/math/discrete/graph/vertex.rb
+++ b/lib/math/discrete/graph/vertex.rb
@@ -20,17 +20,19 @@ class Math::Discrete::Graph::Vertex
   end
 
   def adjacent_to?(other_vertex)
-    raise Math::Discrete::TypeError, 'other_vertex must be of type Math::Discrete::Vertex' unless other_vertex.is_a? Vertex
+    raise TypeError, 'other_vertex must be of type Math::Discrete::Vertex' unless other_vertex.is_a? Vertex
 
     @adjacent_vertices.include? other_vertex
   end
 
   def distance_to(other_vertex)
-    raise Math::Discrete::Graph::VertexNotFound, '' unless adjacent_to
+    raise Math::Discrete::Graph::VertexNotFound, 'vertex must be adjacent' unless adjacent_to? other_vertex
+
+    @edge_weights[other_vertex.label]
   end
 
   def ==(other_vertex)
-    raise Math::Discrete::TypeError, 'other_vertex must be of type Math::Discrete::Vertex' unless other_vertex.is_a? Vertex
+    raise TypeError, 'other_vertex must be of type Math::Discrete::Vertex' unless other_vertex.is_a? Vertex
 
     label == other_vertex.label
   end

--- a/lib/math/discrete/property.rb
+++ b/lib/math/discrete/property.rb
@@ -18,13 +18,13 @@ class Math::Discrete::Property
 
   def satisfied?(structure)
     unless Math::Discrete.const_get(structure_type.capitalize) == structure.class
-      raise Math::Discrete::TypeError, "structure must of type Math::Discrete::#{structure_type.capitalize}"
+      raise TypeError, "structure must of type Math::Discrete::#{structure_type.capitalize}"
     end
 
     result = @satisfiability_test.call structure
 
     unless [true, false].include? result
-      raise Math::Discrete::TypeError, 'satisfiability_test must return a Boolean type'
+      raise TypeError, 'satisfiability_test must return a Boolean type'
     end
 
     result

--- a/spec/graph/algorithms_spec.rb
+++ b/spec/graph/algorithms_spec.rb
@@ -42,7 +42,7 @@ describe Graph::Algorithms do
     it 'raises a TypeError if the root is not a Vertex' do
       expect {
         directed_graph.breadth_first_search root: 'not_a_vertex'
-      }.to raise_error Math::Discrete::TypeError
+      }.to raise_error TypeError
     end
 
     it 'raises a VertexNotFound if the root is not in the graph' do
@@ -69,7 +69,7 @@ describe Graph::Algorithms do
     it 'raises a TypeError if the root is not a Vertex' do
       expect {
         directed_graph.depth_first_search root: 'not_a_vertex'
-      }.to raise_error Math::Discrete::TypeError
+      }.to raise_error TypeError
     end
 
     it 'raises a VertexNotFound if the root is not in the graph' do
@@ -77,5 +77,9 @@ describe Graph::Algorithms do
         directed_graph.depth_first_search root: foreign_vertex
       }.to raise_error Graph::VertexNotFound
     end
+  end
+
+  describe '#shortest_path_between' do
+    skip
   end
 end

--- a/spec/graph/algorithms_spec.rb
+++ b/spec/graph/algorithms_spec.rb
@@ -1,12 +1,10 @@
 require 'spec_helper'
 
 describe Graph::Algorithms do
-  let(:empty_directed_graph) { Graph.build }
+  let(:empty_directed_graph) { Graph[] }
   let(:empty_undirected_graph) { Graph.build directed: false }
-  let(:directed_graph) {
-    Graph.build_from_labels vertex_labels: Set[1,2,3,4], edge_labels: Set[[1,2],[2,3],[3,1], [1,4], [4,2]]
-  }
-  let(:foreign_vertex) { Graph::Vertex.build_from_label 'Z' }
+  let(:directed_graph) { Graph[[1,2,3,4], [[1,2],[2,3],[3,1], [1,4], [4,2]]] }
+  let(:foreign_vertex) { Vertex['Z'] }
 
   describe '#breadth_first_search' do
     let(:search_tree) { directed_graph.breadth_first_search }

--- a/spec/graph/algorithms_spec.rb
+++ b/spec/graph/algorithms_spec.rb
@@ -10,12 +10,12 @@ describe Graph::Algorithms do
     let(:search_tree) { directed_graph.breadth_first_search }
 
     it 'returns an empty search tree if the graph is empty' do
-      expect(empty_directed_graph.breadth_first_search).to be_a Hash
+      expect(empty_directed_graph.breadth_first_search).to be_an_instance_of Hash
       expect(empty_directed_graph.breadth_first_search).to be_empty
     end
 
     it 'returns a valid search tree in Hash form' do
-      expect(search_tree).to be_a Hash
+      expect(search_tree).to be_an_instance_of Hash
       expect(search_tree).not_to be_empty
       expect(search_tree.keys).to contain_exactly *directed_graph.vertex_labels
     end
@@ -56,12 +56,12 @@ describe Graph::Algorithms do
     let(:search_tree) { directed_graph.depth_first_search }
 
     it 'returns an empty search tree if the graph is empty' do
-      expect(empty_directed_graph.depth_first_search).to be_a Hash
+      expect(empty_directed_graph.depth_first_search).to be_an_instance_of Hash
       expect(empty_directed_graph.depth_first_search).to be_empty
     end
 
     it 'returns a valid search tree in Hash form' do
-      expect(search_tree).to be_a Hash
+      expect(search_tree).to be_an_instance_of Hash
       expect(search_tree).not_to be_empty
       expect(search_tree.keys).to contain_exactly *directed_graph.vertex_labels
     end
@@ -80,6 +80,69 @@ describe Graph::Algorithms do
   end
 
   describe '#shortest_path_between' do
-    skip
+    let(:positive_weight_graph) do
+      Graph[[1,2,3,4,5,6], [[1,2,7],[2,1,7],[1,6,14],[6,1,14],[1,3,9],[3,1,9],[2,3,10],[3,2,10],[3,6,2],[6,3,2],[3,4,11],[4,3,11],[2,4,15],[4,2,15],[4,5,6],[5,4,6],[6,5,9],[5,6,9]]]
+    end
+    let(:source) { positive_weight_graph.find_vertex_by_label! 1 }
+    let(:target) { positive_weight_graph.find_vertex_by_label! 5 }
+    let(:foreign_vertex) { Vertex[7] }
+
+    let(:negative_weight_graph) do
+      Graph[[1,2,3,4,5], [[1,2,-3],[2,3,1],[3,4,1],[4,5,1]]]
+    end
+    let(:source) { negative_weight_graph.find_vertex_by_label! 1 }
+    let(:target) { negative_weight_graph.find_vertex_by_label! 5 }
+
+    it 'raises a TypeError if the source vertex is not of type Vertex' do
+      expect {
+        positive_weight_graph.shortest_path_between 'not a vertex', target
+      }.to raise_error TypeError
+    end
+
+    it 'raises a TypeError if the target vertex is not of type Vertex' do
+      expect {
+        positive_weight_graph.shortest_path_between source, 'not a vertex'
+      }.to raise_error TypeError
+    end
+
+    it 'raises a Graph::VertexNotFound if the source vertex is not in the graph' do
+      expect {
+        positive_weight_graph.shortest_path_between foreign_vertex, target
+      }.to raise_error Graph::VertexNotFound
+    end
+
+    it 'raises a Graph::VertexNotFound if the target vertex is not in the graph' do
+      expect {
+        positive_weight_graph.shortest_path_between source, foreign_vertex
+      }.to raise_error Graph::VertexNotFound
+    end
+
+    it 'returns an empty path if the source and the target are the same vertex' do
+      path = positive_weight_graph.shortest_path_between source, source
+
+      expect(path.edges).to be_empty
+    end
+
+    it 'returns a valid shortest path for graphs with positive-weight edges' do
+      path = positive_weight_graph.shortest_path_between source, target
+
+      expect(path).to be_an_instance_of Graph::Path
+    end
+
+    it 'returns a valid shortest path for graphs with negative-weight edges' do
+      path = negative_weight_graph.shortest_path_between source, target
+
+      expect(path).to be_an_instance_of Graph::Path
+    end
+
+    it 'raises a NegativeWeightCycleError if the graph contains a negative-weight cycle' do
+      negative_weight_cycle_graph = Graph[[1,2,3,4,5], [[1,2,5],[2,3,-1],[3,4,-1],[4,2,-1],[2,5,1]]]
+      source = negative_weight_cycle_graph.find_vertex_by_label! 1
+      target = negative_weight_cycle_graph.find_vertex_by_label! 5
+
+      expect {
+        negative_weight_cycle_graph.shortest_path_between source, target
+      }.to raise_error Graph::Algorithms::NegativeWeightCycleError
+    end
   end
 end

--- a/spec/graph/edge_spec.rb
+++ b/spec/graph/edge_spec.rb
@@ -77,7 +77,7 @@ describe Math::Discrete::Graph::Edge do
     it 'returns a set of labels of the vertices connected by the edge' do
       labels = directed_edge.labels
 
-      expect(labels).to be_a Set
+      expect(labels).to be_an_instance_of Set
       expect(labels).to contain_exactly 'A', 'B'
     end
   end
@@ -86,7 +86,7 @@ describe Math::Discrete::Graph::Edge do
     it 'returns a set of the vertices connected by the edge' do
       vertices = directed_edge.vertices
 
-      expect(vertices).to be_a Set
+      expect(vertices).to be_an_instance_of Set
       expect(vertices).to contain_exactly first_vertex, second_vertex
     end
   end

--- a/spec/graph/edge_spec.rb
+++ b/spec/graph/edge_spec.rb
@@ -82,9 +82,9 @@ describe Math::Discrete::Graph::Edge do
     end
   end
 
-  describe '#to_set' do
+  describe '#vertices' do
     it 'returns a set of the vertices connected by the edge' do
-      vertices = directed_edge.to_set
+      vertices = directed_edge.vertices
 
       expect(vertices).to be_a Set
       expect(vertices).to contain_exactly first_vertex, second_vertex

--- a/spec/graph/edge_spec.rb
+++ b/spec/graph/edge_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Math::Discrete::Graph::Edge do
-  let(:first_vertex) { Graph::Vertex.build_from_label 'A' }
-  let(:second_vertex) { Graph::Vertex.build_from_label 'B' }
-  let(:directed_edge) { described_class::Directed.build from: first_vertex, to: second_vertex }
-  let(:undirected_edge) { described_class::Undirected.build_between first_vertex, second_vertex }
+  let(:first_vertex) { Vertex['A'] }
+  let(:second_vertex) { Vertex['B'] }
+  let(:directed_edge) { Edge::Directed[first_vertex, second_vertex] }
+  let(:undirected_edge) { Edge::Undirected[first_vertex, second_vertex] }
 
   context '::Directed' do
     describe '::build' do
@@ -19,12 +19,12 @@ describe Math::Discrete::Graph::Edge do
       end
 
       it 'raises a TypeError when given objects of non-Vertex type as input' do
-        expect { described_class::Directed.build from: 'Not a vertex', to: second_vertex }.to raise_error Math::Discrete::TypeError
-        expect { described_class::Directed.build from: first_vertex, to: 'Not a vertex' }.to raise_error Math::Discrete::TypeError
+        expect { Edge::Directed['Not a vertex', second_vertex] }.to raise_error TypeError
+        expect { Edge::Directed[first_vertex, 'Not a vertex'] }.to raise_error TypeError
       end
 
       it 'raises a TypeError when given a non-numeric weight' do
-        expect { described_class::Directed.build from: 'Not a vertex', to: second_vertex, weight: '1' }.to raise_error Math::Discrete::TypeError
+        expect { Edge::Directed['Not a vertex', second_vertex, '1'] }.to raise_error TypeError
       end
     end
   end
@@ -42,20 +42,20 @@ describe Math::Discrete::Graph::Edge do
       end
 
       it 'raises a TypeError when given objects of non-Vertex type as input' do
-        expect { described_class::Undirected.build_between 'Not a vertex', second_vertex }.to raise_error Math::Discrete::TypeError
-        expect { described_class::Undirected.build_between first_vertex, 'Not a vertex' }.to raise_error Math::Discrete::TypeError
+        expect { Edge::Undirected['Not a vertex', second_vertex] }.to raise_error TypeError
+        expect { Edge::Undirected[first_vertex, 'Not a vertex'] }.to raise_error TypeError
       end
 
       it 'raises a TypeError when given a non-numeric weight' do
-        expect { described_class::Undirected.build_between 'Not a vertex', second_vertex, weight: '1' }.to raise_error Math::Discrete::TypeError
+        expect { Edge::Undirected['Not a vertex', second_vertex, '1'] }.to raise_error TypeError
       end
     end
   end
 
   describe '#==' do
-    let(:third_vertex) { Graph::Vertex.build_from_label 'B' }
-    let(:same_undirected_edge) { described_class::Undirected.build_between second_vertex, first_vertex }
-    let(:same_directed_edge) { described_class::Directed.build from: first_vertex, to: second_vertex }
+    let(:third_vertex) { Vertex['B'] }
+    let(:same_undirected_edge) { Edge::Undirected[second_vertex, first_vertex] }
+    let(:same_directed_edge) { Edge::Directed[first_vertex, second_vertex] }
 
     it 'returns false when undirected and other_edge is directed or vice versa' do
       expect(directed_edge).not_to eq undirected_edge

--- a/spec/graph/graph_spec.rb
+++ b/spec/graph/graph_spec.rb
@@ -24,21 +24,25 @@ describe Math::Discrete::Graph do
     let(:graph_from_labels) { Graph[[1, 2, 3], [[1, 2], [2, 3], [3, 1], [1, 3]]] }
 
     it 'raises a TypeError if the given vertex set or label set is not a Set or an Array' do
-      expect { Graph['vertices', []] }.to raise_error TypeError
+      expect {
+        Graph['vertices', []]
+      }.to raise_error TypeError
     end
 
     it 'raises a TypeError if the given edge set or label set is not a Set or an Array' do
-      expect { Graph[[], 'edges'] }.to raise_error TypeError
+      expect {
+        Graph[[], 'edges']
+      }.to raise_error TypeError
     end
 
     it 'builds a graph from the given vertex set and edge set' do
-      expect(directed_graph_from_sets).to be_a Graph
+      expect(directed_graph_from_sets).to be_an_instance_of Graph
       expect(directed_graph_from_sets.vertex_set).to eq vertex_set
       expect(directed_graph_from_sets.edge_set).to eq directed_edge_set
     end
 
     it 'builds a directed graph from the given vertex label set and edge label set' do
-      expect(graph_from_labels).to be_a Graph
+      expect(graph_from_labels).to be_an_instance_of Graph
       expect(graph_from_labels).to be_directed
       expect(graph_from_labels.vertex_labels).to contain_exactly 1, 2, 3
     end
@@ -62,13 +66,17 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises a TypeError if the input is an object of a non-Vertex type' do
-      expect { graph.add_vertex! 'This is not a vertex' }.to raise_error TypeError
+      expect {
+        graph.add_vertex! 'This is not a vertex'
+      }.to raise_error TypeError
     end
 
     it 'raises a VertexNotUnique if the vertex is already part of the vertex set' do
       graph.add_vertex! vertex
 
-      expect { graph.add_vertex! vertex }.to raise_error Graph::VertexNotUnique
+      expect {
+        graph.add_vertex! vertex
+      }.to raise_error Graph::VertexNotUnique
     end
   end
 
@@ -82,13 +90,17 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises a TypeError if the input includes an object of a non-Vertex type' do
-      expect { graph.add_vertices!(vertices << 'This is not a vertex') }.to raise_error TypeError
+      expect {
+        graph.add_vertices!(vertices << 'This is not a vertex')
+      }.to raise_error TypeError
     end
 
     it 'raises a VertexNotUnique if the input includes a vertex that is already part of the vertex set' do
       graph.add_vertex! vertices.first
 
-      expect { graph.add_vertices! vertices }.to raise_error Graph::VertexNotUnique
+      expect {
+        graph.add_vertices! vertices
+      }.to raise_error Graph::VertexNotUnique
     end
   end
 
@@ -105,7 +117,9 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises a TypeError if the input is an object of a non-Edge type' do
-      expect { directed_graph.add_edge! 'This is not an edge' }.to raise_error TypeError
+      expect {
+        directed_graph.add_edge! 'This is not an edge'
+      }.to raise_error TypeError
     end
 
     it 'raises a EdgeNotUnique if the edge is already part of the edge set' do
@@ -136,7 +150,9 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises a TypeError if the input includes an object of a non-Edge type' do
-      expect { directed_graph.add_edges!(directed_edges << 'This is not an edge') }.to raise_error TypeError
+      expect {
+        directed_graph.add_edges!(directed_edges << 'This is not an edge')
+      }.to raise_error TypeError
     end
 
     it 'raises a EdgeNotUnique if the input includes an edge that is already part of the edge set' do
@@ -172,7 +188,9 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises a TypeError if the input is an object of non-Vertex type' do
-      expect { graph.remove_vertex! 'This is not a vertex' }.to raise_error TypeError
+      expect {
+        graph.remove_vertex! 'This is not a vertex'
+      }.to raise_error TypeError
     end
 
     it 'raises a VertexNotFound if the input is a vertex that is not part of the vertex set' do
@@ -200,7 +218,9 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises a TypeError if the input is an object of non-Vertex type' do
-      expect { graph.remove_vertices! %w(This is not a vertex) }.to raise_error TypeError
+      expect {
+        graph.remove_vertices! %w(This is not a vertex)
+      }.to raise_error TypeError
     end
 
     it 'raises a VertexNotFound if the input is a vertex that is not part of the vertex set' do
@@ -222,7 +242,9 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises a TypeError if the input is an object of non-Edge type' do
-      expect { graph.remove_edge! 'This is not a vertex' }.to raise_error TypeError
+      expect {
+        graph.remove_edge! 'This is not a vertex'
+      }.to raise_error TypeError
     end
 
     it 'raises an EdgeNotFound if the input is an edge that is not part of the edge set' do
@@ -244,7 +266,9 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises a TypeError if the input includes an an object of non-Edge type' do
-      expect { graph.remove_edges! %w(This is not an edge) }.to raise_error TypeError
+      expect {
+        graph.remove_edges! %w(This is not an edge)
+      }.to raise_error TypeError
     end
 
     it 'raises an EdgeNotFound if the input includes an edge that is not part of the edge set' do
@@ -261,7 +285,7 @@ describe Math::Discrete::Graph do
     it 'returns the vertex with the given label in the vertex set' do
       result = graph.find_vertex_by_label! 1
 
-      expect(result).to be_a Vertex
+      expect(result).to be_an_instance_of Vertex
       expect(result.label).to eq 1
     end
 
@@ -276,8 +300,8 @@ describe Math::Discrete::Graph do
     let(:result) { graph.find_vertices_by_labels! *labels }
 
     it 'returns the vertices with the given labels in the vertex set' do
-      expect(result).to be_a Set
-      expect(result).to all be_a Vertex
+      expect(result).to be_an_instance_of Set
+      expect(result).to all be_an_instance_of Vertex
       expect(result.size).to be 2
       expect(result.map &:label).to contain_exactly *labels
     end
@@ -299,13 +323,13 @@ describe Math::Discrete::Graph do
     let(:undirected_result) { undirected_graph.find_edge_by_labels! *labels.entries.reverse }
 
     it 'returns the directed edge with the given labels in order in the edge set' do
-      expect(directed_result).to be_a Edge
+      expect(directed_result).to be_an_instance_of Edge
       expect(directed_result).to be_directed
       expect(directed_result.labels).to contain_exactly *labels
     end
 
     it 'returns the undirected edge with the given labels regardless of order in the edge set' do
-      expect(undirected_edge).to be_a Edge
+      expect(undirected_edge).to be_an_instance_of Edge
       expect(undirected_edge).not_to be_directed
       expect(undirected_result.labels).to contain_exactly *labels
     end
@@ -322,6 +346,17 @@ describe Math::Discrete::Graph do
 
     it 'returns a set of all the vertex labels' do
       expect(graph.vertex_labels).to contain_exactly *labels
+    end
+  end
+
+  describe '#edge_labels' do
+    let(:vertices) { Vertex::Set[*labels] }
+    let(:directed_edges) { Edge::Set::Directed[[*vertices]] }
+    let(:directed_graph) { Graph[vertices, directed_edges] }
+
+    it 'returns a set of all the edge labels' do
+      expect(directed_graph.edge_labels).to contain_exactly *directed_edges.map(&:labels)
+      expect(directed_graph.edge_labels).to be_an_instance_of Set
     end
   end
 

--- a/spec/graph/graph_spec.rb
+++ b/spec/graph/graph_spec.rb
@@ -1,137 +1,68 @@
 require 'spec_helper'
 
 describe Math::Discrete::Graph do
-  let(:directed_graph) { Graph.build }
-  let(:undirected_graph) { Graph.build directed: false }
-  let(:labels) { Set['A', 'B'] }
+  let(:labels) { [1, 2] }
 
   describe '::[]' do
-    let(:vertex_set) { Graph::Vertex.build_from_labels 'A', 'B', 'C' }
-    let(:edge_set) do
-      Set[
-        Edge::Directed.build(from: vertex_set.entries[0], to: vertex_set.entries[1]),
-        Edge::Directed.build(from: vertex_set.entries[1], to: vertex_set.entries[0]),
-        Edge::Directed.build(from: vertex_set.entries[1], to: vertex_set.entries[2]),
-        Edge::Directed.build(from: vertex_set.entries[2], to: vertex_set.entries[1])
+    let(:vertex_set) { Vertex::Set['A', 'B', 'C'] }
+    let(:directed_edge_set) do
+      Edge::Set::Directed[
+        [vertex_set.entries[0], vertex_set.entries[1]],
+        [vertex_set.entries[1], vertex_set.entries[0]],
+        [vertex_set.entries[1], vertex_set.entries[2]],
+        [vertex_set.entries[2], vertex_set.entries[1]]
       ]
     end
-    let(:graph_from_sets) { Graph[vertex_set, edge_set] }
+    let(:undirected_edge_set) do
+      Edge::Set::Undirected[
+        [vertex_set.entries[0], vertex_set.entries[1]],
+        [vertex_set.entries[1], vertex_set.entries[2]],
+      ]
+    end
+    let(:directed_graph_from_sets) { Graph[vertex_set, directed_edge_set] }
+    let(:undirected_graph_from_sets) { Graph[vertex_set, undirected_edge_set] }
     let(:graph_from_labels) { Graph[[1, 2, 3], [[1, 2], [2, 3], [3, 1], [1, 3]]] }
 
     it 'raises a TypeError if the given vertex set or label set is not a Set or an Array' do
-      expect { Graph['vertices', Set[]] }.to raise_error Math::Discrete::TypeError
+      expect { Graph['vertices', []] }.to raise_error TypeError
     end
 
     it 'raises a TypeError if the given edge set or label set is not a Set or an Array' do
-      expect { Graph[Set[], 'edges'] }.to raise_error Math::Discrete::TypeError
+      expect { Graph[[], 'edges'] }.to raise_error TypeError
     end
 
     it 'builds a graph from the given vertex set and edge set' do
-      expect(graph_from_sets).to be_a Graph
-      expect(graph_from_sets.vertex_set).to eq vertex_set
-      expect(graph_from_sets.edge_set).to eq edge_set
+      expect(directed_graph_from_sets).to be_a Graph
+      expect(directed_graph_from_sets.vertex_set).to eq vertex_set
+      expect(directed_graph_from_sets.edge_set).to eq directed_edge_set
     end
 
-    it 'builds a graph from the given vertex label set and edge label set' do
+    it 'builds a directed graph from the given vertex label set and edge label set' do
       expect(graph_from_labels).to be_a Graph
-      expect(graph_from_labels.vertex_labels).to eq Set[1, 2, 3]
-    end
-  end
-
-  describe '::build' do
-    describe 'directed: true' do
-      it 'creates a directed graph with an empty vertex set and edge set' do
-        expect(directed_graph.vertex_set).to be_empty
-        expect(directed_graph.edge_set).to be_empty
-        expect(directed_graph).to be_directed
-      end
+      expect(graph_from_labels).to be_directed
+      expect(graph_from_labels.vertex_labels).to contain_exactly 1, 2, 3
     end
 
-    describe 'directed: false' do
-      it 'creates an undirected graph with an empty vertex set and edge set' do
-        expect(undirected_graph.vertex_set).to be_empty
-        expect(undirected_graph.edge_set).to be_empty
-        expect(undirected_graph).not_to be_directed
-      end
-    end
-  end
-
-  describe '::build_from_sets' do
-    let(:vertex_set) { Graph::Vertex.build_from_labels 'A', 'B', 'C' }
-    let(:directed_edge_set) do
-      Set[
-        Edge::Directed.build(from: vertex_set.entries[0], to: vertex_set.entries[1]),
-        Edge::Directed.build(from: vertex_set.entries[1], to: vertex_set.entries[0]),
-        Edge::Directed.build(from: vertex_set.entries[1], to: vertex_set.entries[2]),
-        Edge::Directed.build(from: vertex_set.entries[2], to: vertex_set.entries[1])
-      ]
-    end
-
-    let(:undirected_edge_set) do
-      Set[
-        Edge::Undirected.build_between(vertex_set.entries[0], vertex_set.entries[1]),
-        Edge::Undirected.build_between(vertex_set.entries[1], vertex_set.entries[2]),
-      ]
-    end
-
-    let(:directed_graph) { Graph.build_from_sets vertex_set: vertex_set, edge_set: directed_edge_set }
-    let(:undirected_graph) { Graph.build_from_sets vertex_set: vertex_set, edge_set: undirected_edge_set }
-
-    it 'creates a graph from the given sets of vertices and edges' do
-      expect(directed_graph).to be_a Graph
-      expect(directed_graph).to be_directed
-      expect(directed_graph.vertex_set).to eq vertex_set
-      expect(directed_graph.edge_set).to eq directed_edge_set
-
-      expect(undirected_graph).to be_a Graph
-      expect(undirected_graph).not_to be_directed
-      expect(undirected_graph.vertex_set).to eq vertex_set
-      expect(undirected_graph.edge_set).to eq undirected_edge_set
-    end
-
-    it 'creates a directed or undirected graph based on the edge set' do
+    it 'builds a directed or undirected graph based on the edge set' do
       expect(directed_edge_set).to all be_directed
-      expect(directed_graph).to be_directed
+      expect(directed_graph_from_sets).to be_directed
 
       expect(undirected_edge_set).to all satisfy { |edge| !edge.directed? }
-      expect(undirected_graph).not_to be_directed
-    end
-  end
-
-  describe '::build_from_labels' do
-    let(:vertex_labels) { Set['A', 'B', 'C', 'D'] }
-    let(:edge_labels) { Set[*[%w(A D), %w(B D), %w(A C)].map(&:to_set)] }
-    let(:directed_graph) { Graph.build_from_labels vertex_labels: vertex_labels, edge_labels: edge_labels }
-    let(:undirected_graph) { Graph.build_from_labels directed: false, vertex_labels: vertex_labels, edge_labels: edge_labels }
-
-    it 'creates a directed graph from the given sets of labels by default' do
-      expect(directed_graph).to be_a Graph
-      expect(directed_graph).to be_directed
-      expect(directed_graph.vertex_labels).to eq vertex_labels
-      expect(directed_graph.edge_labels).to eq edge_labels
-      expect(directed_graph.edge_set).to all be_directed
-    end
-
-    it 'creates an undirected graph from the given sets of labels when passed directed: false' do
-      expect(undirected_graph).to be_a Graph
-      expect(undirected_graph).not_to be_directed
-      expect(undirected_graph.vertex_labels).to eq vertex_labels
-      expect(undirected_graph.edge_set).to all( satisfy { |edge| !edge.directed? })
-      expect(undirected_graph.edge_labels).to eq edge_labels
+      expect(undirected_graph_from_sets).not_to be_directed
     end
   end
 
   describe '#add_vertex!, #add_node!' do
-    let(:graph) { Graph.build }
-    let(:vertex) { Graph::Vertex.build_from_label 'A' }
+    let(:graph) { Graph[] }
+    let(:vertex) { Vertex['A'] }
 
     it 'adds the vertex to the vertex set' do
-      expect { graph.add_vertex! vertex }.to change(graph.vertex_set, :count).by 1
+      graph.add_vertex! vertex
       expect(graph.vertex_set).to include vertex
     end
 
     it 'raises a TypeError if the input is an object of a non-Vertex type' do
-      expect { graph.add_vertex! 'This is not a vertex' }.to raise_error Math::Discrete::TypeError
+      expect { graph.add_vertex! 'This is not a vertex' }.to raise_error TypeError
     end
 
     it 'raises a VertexNotUnique if the vertex is already part of the vertex set' do
@@ -142,16 +73,16 @@ describe Math::Discrete::Graph do
   end
 
   describe '#add_vertices!, #add_nodes!' do
-    let(:graph) { Graph.build }
-    let(:vertices) { Graph::Vertex.build_from_labels *labels }
+    let(:graph) { Graph[] }
+    let(:vertices) { Vertex::Set[*labels] }
 
     it 'adds the vertices to the vertex set' do
-      expect { graph.add_vertices! vertices }.to change(graph.vertex_set, :count).by 2
+      graph.add_vertices! vertices
       expect(graph.vertex_set).to include *vertices
     end
 
     it 'raises a TypeError if the input includes an object of a non-Vertex type' do
-      expect { graph.add_vertices!(vertices << 'This is not a vertex') }.to raise_error Math::Discrete::TypeError
+      expect { graph.add_vertices!(vertices << 'This is not a vertex') }.to raise_error TypeError
     end
 
     it 'raises a VertexNotUnique if the input includes a vertex that is already part of the vertex set' do
@@ -162,19 +93,19 @@ describe Math::Discrete::Graph do
   end
 
   describe '#add_edge!' do
-    let(:vertices) { Graph::Vertex.build_from_labels *labels }
-    let(:directed_graph) { Graph.build_from_sets vertex_set: vertices }
+    let(:vertices) { Vertex::Set[*labels] }
+    let(:directed_graph) { Graph[vertices, []] }
     let(:undirected_graph) { Graph.build directed: false }
-    let(:directed_edge) { Graph::Edge::Directed.build from: vertices.entries[0], to: vertices.entries[1] }
-    let(:undirected_edge) { Graph::Edge::Undirected.build_between *vertices}
+    let(:directed_edge) { Edge::Directed[*vertices] }
+    let(:undirected_edge) { Edge::Undirected[*vertices] }
 
     it 'adds the edge to the edge set' do
-      expect { directed_graph.add_edge! directed_edge }.to change(directed_graph.edge_set, :count).by 1
+      directed_graph.add_edge! directed_edge
       expect(directed_graph.edge_set).to include directed_edge
     end
 
     it 'raises a TypeError if the input is an object of a non-Edge type' do
-      expect { directed_graph.add_edge! 'This is not an edge' }.to raise_error Math::Discrete::TypeError
+      expect { directed_graph.add_edge! 'This is not an edge' }.to raise_error TypeError
     end
 
     it 'raises a EdgeNotUnique if the edge is already part of the edge set' do
@@ -193,19 +124,19 @@ describe Math::Discrete::Graph do
   end
 
   describe '#add_edges!' do
-    let(:vertices) { Graph::Vertex.build_from_labels *labels }
-    let(:directed_graph) { Graph.build_from_sets vertex_set: vertices }
+    let(:vertices) { Vertex::Set[*labels] }
+    let(:directed_graph) { Graph[vertices] }
     let(:undirected_graph) { Graph.build directed: false }
-    let(:directed_edges) { Set[Graph::Edge::Directed.build from: vertices.entries[0], to: vertices.entries[1]] }
-    let(:undirected_edges) { Set[Graph::Edge::Undirected.build_between *vertices] }
+    let(:directed_edges) { Edge::Set::Directed[[*vertices]] }
+    let(:undirected_edges) { Edge::Set::Undirected[[*vertices]] }
 
     it 'adds the edges to the edge set' do
-      expect { directed_graph.add_edges! directed_edges }.to change(directed_graph.edge_set, :count).by 1
+      directed_graph.add_edges! directed_edges
       expect(directed_graph.edge_set).to include *directed_edges
     end
 
     it 'raises a TypeError if the input includes an object of a non-Edge type' do
-      expect { directed_graph.add_edges!(directed_edges << 'This is not an edge') }.to raise_error Math::Discrete::TypeError
+      expect { directed_graph.add_edges!(directed_edges << 'This is not an edge') }.to raise_error TypeError
     end
 
     it 'raises a EdgeNotUnique if the input includes an edge that is already part of the edge set' do
@@ -224,113 +155,114 @@ describe Math::Discrete::Graph do
   end
 
   describe '#remove_vertex!, #remove_node!' do
-    let(:vertices) { Graph::Vertex.build_from_labels *labels }
+    let(:vertices) { Vertex::Set[*labels] }
     let(:vertex) { vertices.first }
-    let(:edge) { Graph::Edge::Undirected.build_between *vertices }
-    let(:edges) { Set[edge] }
-    let(:graph) { Graph.build_from_sets vertex_set: vertices, edge_set: edges }
+    let(:edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:edge) { edges.first }
+    let(:graph) { Graph[vertices, edges] }
 
     it 'removes the vertex from the vertex set' do
-      expect { graph.remove_vertex! vertex }.to change(graph.vertex_set, :count).by -1
+      graph.remove_vertex! vertex
       expect(graph.vertex_set).not_to include vertex
     end
 
     it 'removes the edges incident to the vertex from the edge set' do
-      expect { graph.remove_vertex! vertex }.to change(graph.edge_set, :count).by -1
+      graph.remove_vertex! vertex
       expect(graph.edge_set).not_to include edge
     end
 
     it 'raises a TypeError if the input is an object of non-Vertex type' do
-      expect { graph.remove_vertex! 'This is not a vertex' }.to raise_error Math::Discrete::TypeError
+      expect { graph.remove_vertex! 'This is not a vertex' }.to raise_error TypeError
     end
 
     it 'raises a VertexNotFound if the input is a vertex that is not part of the vertex set' do
-      foreign_vertex = Graph::Vertex.build_from_label 'Z'
+      foreign_vertex = Vertex['Z']
 
       expect { graph.remove_vertex! foreign_vertex }.to raise_error Graph::VertexNotFound
     end
   end
 
   describe '#remove_vertices!, #remove_nodes!' do
-    let(:vertices) { Graph::Vertex.build_from_labels *labels }
+    let(:vertices) { Vertex::Set[*labels] }
     let(:vertex) { vertices.first }
-    let(:edge) { Graph::Edge::Undirected.build_between *vertices }
-    let(:edges) { Set[edge] }
-    let(:graph) { Graph.build_from_sets vertex_set: vertices, edge_set: edges }
+    let(:edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:edge) { edges.first }
+    let(:graph) { Graph[vertices, edges] }
 
     it 'removes the vertices from the vertex set' do
-      expect { graph.remove_vertices! vertices }.to change(graph.vertex_set, :count).by -2
+      graph.remove_vertices! vertices
       expect(graph.vertex_set).not_to include *vertices
     end
 
     it 'removes the edges incident to the vertices from the edge set' do
-      expect { graph.remove_vertices! vertices }.to change(graph.edge_set, :count).by -1
+      graph.remove_vertices! vertices
       expect(graph.edge_set).not_to include edge
     end
 
     it 'raises a TypeError if the input is an object of non-Vertex type' do
-      expect { graph.remove_vertices! %w(This is not a vertex) }.to raise_error Math::Discrete::TypeError
+      expect { graph.remove_vertices! %w(This is not a vertex) }.to raise_error TypeError
     end
 
     it 'raises a VertexNotFound if the input is a vertex that is not part of the vertex set' do
-      foreign_vertex = Graph::Vertex.build_from_label 'Z'
+      foreign_vertex = Vertex['Z']
 
       expect { graph.remove_vertices! vertices.add(foreign_vertex) }.to raise_error Graph::VertexNotFound
     end
   end
 
-  describe '#remove_edge' do
-    let(:vertices) { Graph::Vertex.build_from_labels *labels }
-    let(:edge) { Graph::Edge::Directed.build from: vertices.entries[0], to: vertices.entries[1] }
-    let(:edges) { Set[edge] }
-    let(:graph) { Graph.build_from_sets vertex_set: vertices, edge_set: edges }
+  describe '#remove_edge!' do
+    let(:vertices) { Vertex::Set[*labels] }
+    let(:edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:edge) { edges.first }
+    let(:graph) { Graph[vertices, edges] }
 
     it 'removes the edge from the edge set' do
-      expect { graph.remove_edge! edge }.to change(graph.edge_set, :count).by -1
+      graph.remove_edge! edge
       expect(graph.edge_set).not_to include edge
     end
 
     it 'raises a TypeError if the input is an object of non-Edge type' do
-      expect { graph.remove_edge! 'This is not a vertex' }.to raise_error Math::Discrete::TypeError
+      expect { graph.remove_edge! 'This is not a vertex' }.to raise_error TypeError
     end
 
     it 'raises an EdgeNotFound if the input is an edge that is not part of the edge set' do
-      foreign_edge = Graph::Edge::Undirected.build_between *vertices
+      foreign_edge = Edge::Undirected[*vertices]
 
       expect { graph.remove_edge! foreign_edge }.to raise_error Graph::EdgeNotFound
     end
   end
 
-  describe '#remove_edges' do
-    let(:vertices) { Graph::Vertex.build_from_labels *labels }
-    let(:edge) { Graph::Edge::Directed.build from: vertices.entries[0], to: vertices.entries[1] }
-    let(:edges) { Set[edge] }
-    let(:graph) { Graph.build_from_sets vertex_set: vertices, edge_set: edges }
+  describe '#remove_edges!' do
+    let(:vertices) { Vertex::Set[*labels] }
+    let(:edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:edge) { edges.first }
+    let(:graph) { Graph[vertices, edges] }
 
     it 'removes the edge from the edge set' do
-      expect { graph.remove_edges! edges }.to change(graph.edge_set, :count).by -1
+      graph.remove_edges! edges
       expect(graph.edge_set).not_to include *edge
     end
 
     it 'raises a TypeError if the input includes an an object of non-Edge type' do
-      expect { graph.remove_edges! %w(This is not an edge) }.to raise_error Math::Discrete::TypeError
+      expect { graph.remove_edges! %w(This is not an edge) }.to raise_error TypeError
     end
 
     it 'raises an EdgeNotFound if the input includes an edge that is not part of the edge set' do
-      foreign_edge = Graph::Edge::Undirected.build_between *vertices
+      foreign_edge = Edge::Undirected[*vertices]
 
       expect { graph.remove_edges! [foreign_edge] }.to raise_error Graph::EdgeNotFound
     end
   end
 
   describe '#find_vertex_by_label!' do
-    let(:vertices) { Graph::Vertex.build_from_labels 'A' }
-    let(:graph) { Graph.build_from_sets vertex_set: vertices }
-    let(:result) { graph.find_vertex_by_label! 'A' }
+    let(:vertex) { Vertex[1] }
+    let(:graph) { Graph[[vertex], []] }
 
     it 'returns the vertex with the given label in the vertex set' do
+      result = graph.find_vertex_by_label! 1
+
       expect(result).to be_a Vertex
-      expect(result.label).to eq 'A'
+      expect(result.label).to eq 1
     end
 
     it 'raises VertexNotFound if the vertex set does not include a vertex with the given label' do
@@ -339,8 +271,8 @@ describe Math::Discrete::Graph do
   end
 
   describe '#find_vertices_by_labels!' do
-    let(:vertices) { Graph::Vertex.build_from_labels *labels }
-    let(:graph) { Graph.build_from_sets vertex_set: vertices}
+    let(:vertices) { Vertex::Set[*labels] }
+    let(:graph) { Graph[vertices, []]}
     let(:result) { graph.find_vertices_by_labels! *labels }
 
     it 'returns the vertices with the given labels in the vertex set' do
@@ -356,13 +288,13 @@ describe Math::Discrete::Graph do
   end
 
   describe '#find_edge_by_labels!' do
-    let(:vertices) { Graph::Vertex.build_from_labels *labels }
-    let(:directed_edge) { Graph::Edge::Directed.build from: vertices.entries[0], to: vertices.entries[1] }
-    let(:directed_edges) { Set[directed_edge] }
-    let(:undirected_edge) { Graph::Edge::Undirected.build_between *vertices }
-    let(:undirected_edges) { Set[undirected_edge] }
-    let(:directed_graph) { Graph.build_from_sets vertex_set: vertices, edge_set: directed_edges }
-    let(:undirected_graph) { Graph.build_from_sets vertex_set: vertices, edge_set: undirected_edges }
+    let(:vertices) { Vertex::Set[*labels] }
+    let(:directed_edges) { Edge::Set::Directed[[*vertices]] }
+    let(:directed_edge) { directed_edges.first }
+    let(:undirected_edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:undirected_edge) { undirected_edges.first }
+    let(:directed_graph) { Graph[vertices, directed_edges] }
+    let(:undirected_graph) { Graph[vertices, undirected_edges] }
     let(:directed_result) { directed_graph.find_edge_by_labels! *labels }
     let(:undirected_result) { undirected_graph.find_edge_by_labels! *labels.entries.reverse }
 
@@ -385,52 +317,57 @@ describe Math::Discrete::Graph do
   end
 
   describe '#vertex_labels' do
-    let(:vertices) { Graph::Vertex.build_from_labels 'A', 'B' }
-    let(:graph) { Graph.build_from_sets vertex_set: vertices }
+    let(:vertices) { Vertex::Set[*labels] }
+    let(:graph) { Graph[vertices, []] }
 
     it 'returns a set of all the vertex labels' do
-      expect(graph.vertex_labels).to contain_exactly 'A', 'B'
+      expect(graph.vertex_labels).to contain_exactly *labels
     end
   end
 
   describe '#satisfies_property?' do
     let(:property) { Graph::Properties.all.sample }
+    let(:graph) { Graph[] }
+
     it 'caches results of previous queries' do
       expect(property).to receive(:satisfied?).once
 
-      undirected_graph.satisfies? property
+      graph.satisfies? property
 
-      expect(undirected_graph.properties).not_to be_empty
-      expect(undirected_graph.properties).to include property.name
+      expect(graph.properties).not_to be_empty
+      expect(graph.properties).to include property.name
     end
 
     it 'returns the cached value when possible' do
-      result = undirected_graph.satisfies? property
+      result = graph.satisfies? property
 
       expect(property).to receive(:satisfied?).never
 
-      expect(undirected_graph.satisfies? property).to be result
+      expect(graph.satisfies? property).to be result
     end
   end
 
   describe '#determine_properties!' do
-    it 'checks whether properties in Graph::Properties.all are verified by default' do
-      undirected_graph.determine_properties!
+    let(:graph) { Graph[] }
 
-      expect(undirected_graph.properties).to include *Graph::Properties.all.map(&:name)
+    it 'checks whether properties in Graph::Properties.all are verified by default' do
+      graph.determine_properties!
+
+      expect(graph.properties).to include *Graph::Properties.all.map(&:name)
     end
 
     it 'checks whether the given properties are verified' do
       properties = Graph::Properties.all.sample 2
 
-      undirected_graph.determine_properties! properties
+      graph.determine_properties! properties
 
-      expect(undirected_graph.properties).to include *properties.map(&:name)
+      expect(graph.properties).to include *properties.map(&:name)
     end
   end
 
   describe '#weighted?' do
-    let(:graph) { Graph.build_from_labels vertex_labels: labels, edge_labels: Set[labels]}
+    let(:graph) { Graph[labels, [labels]]}
+    let(:empty_graph) { Graph[] }
 
     it 'returns true if the graph has weighted edges' do
       graph.edge_set.first.weight = 5
@@ -443,8 +380,7 @@ describe Math::Discrete::Graph do
     end
 
     it 'returns false if the graph has no edges' do
-      expect(directed_graph).not_to be_weighted
-      expect(undirected_graph).not_to be_weighted
+      expect(empty_graph).not_to be_weighted
     end
   end
 end

--- a/spec/graph/path_spec.rb
+++ b/spec/graph/path_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Math::Discrete::Graph::Path do
+  let(:vertices) { Vertex::Set[1,2,3,4] }
+  let(:edges) do
+    Edge::Set::Directed[
+      [vertices.entries[0], vertices.entries[1]],
+      [vertices.entries[1], vertices.entries[2]],
+      [vertices.entries[2], vertices.entries[3]]
+    ]
+  end
+  let(:path) { Graph::Path[*edges] }
+
+  describe '::[]' do
+    it 'raises an InvalidPath if the given edges do not make a continuous path' do
+      edges.add Edge::Directed[vertices.entries[2], vertices.entries[0]]
+
+      expect { Graph::Path[*edges] }.to raise_error Graph::Path::InvalidPath
+    end
+
+    it 'creates a new Path object with the given edges' do
+      expect(path).to be_an_instance_of Graph::Path
+      expect(path).to be_an_instance_of Graph::Path
+    end
+  end
+
+  describe '#cyclical?' do
+    it 'returns true if the path ends in the same vertex that it starts with' do
+      edges.add Edge::Directed[vertices.entries[3], vertices.entries[0]]
+      cycle = Graph::Path[*edges]
+
+      expect(cycle).to be_cyclical
+    end
+
+    it 'returns false if the path is not a cycle' do
+      expect(path).not_to be_cyclical
+    end
+  end
+
+  describe '#labels' do
+    let(:labels) { path.labels }
+
+    it 'returns a Set of edge labels' do
+      expect(labels).to be_an_instance_of Set
+      expect(labels).to contain_exactly [1,2], [2,3], [3,4]
+    end
+  end
+
+  describe '#vertices, #nodes' do
+    it 'returns a Set vertices along the path' do
+      expect(path.vertices).to be_an_instance_of Set
+      expect(path.vertices).to contain_exactly *vertices
+    end
+  end
+
+  describe '#length' do
+    it 'returns the number of edges along the path' do
+      expect(Graph::Path[].length).to be 0
+      expect(path.length).to be 3
+    end
+  end
+end

--- a/spec/graph/properties_spec.rb
+++ b/spec/graph/properties_spec.rb
@@ -15,7 +15,7 @@ describe Math::Discrete::Graph::Properties do
   end
 
   described_class::METHODS.each do |property_method|
-    describe property_method do
+    describe "##{property_method}" do
       it "builds a property called #{property_method}" do
         expect(Graph::Properties.send(property_method).name).to be property_method
       end

--- a/spec/graph/properties_spec.rb
+++ b/spec/graph/properties_spec.rb
@@ -1,25 +1,12 @@
 require 'spec_helper'
 
 describe Math::Discrete::Graph::Properties do
-  let(:directed_graph) {
-    Graph.build_from_labels vertex_labels: Set[1,2,3,4], edge_labels: Set[[1,2],[2,3],[3,1], [1,4], [4,2]]
-  }
+  let(:directed_graph) { Graph[[1,2,3,4], [[1,2],[2,3],[3,1], [1,4], [4,2]]] }
+  let(:complete_graph) { Graph[[*(1..5)], (1..5).to_a.permutation(2).to_a] }
+  let(:even_cycle) { Graph[[*(1..10)], [*((1..10).each_cons(2).to_a << [10,1])]] }
+  let(:odd_cycle) { Graph[[*(1..7)], [*((1..7).each_cons(2).to_a << [7,1])]] }
 
-  let(:complete_undirected_graph) {
-    Graph.build_from_labels directed: false, vertex_labels: Set[*(1..5)], edge_labels: Set[*(1..5).to_a.combination(2).to_a]
-  }
-
-  let(:even_cycle) {
-    Graph.build_from_labels vertex_labels: Set[*(1..10)], edge_labels: Set[*((1..10).each_cons(2).to_a << [10,1])]
-  }
-
-  let(:odd_cycle) {
-    Graph.build_from_labels vertex_labels: Set[*(1..7)], edge_labels: Set[*((1..7).each_cons(2).to_a << [7,1])]
-  }
-
-  let(:tree) {
-    Graph.build_from_labels vertex_labels: Set[*(1..7)], edge_labels: Set[[1,2], [1,3], [2,4], [2,5], [3,6], [3,7]]
-  }
+  let(:tree) { Graph[(1..7).to_a, [[1,2], [1,3], [2,4], [2,5], [3,6], [3,7]]] }
 
   describe '::METHODS' do
     it 'returns an array of method names defining properties in the module' do
@@ -52,9 +39,9 @@ describe Math::Discrete::Graph::Properties do
     let(:bipartiteness) { Graph::Properties.bipartiteness }
 
     it 'returns false early if the graph contains too many edges to possibly be bipartite' do
-      expect(complete_undirected_graph).to receive(:breadth_first_search).never
+      expect(complete_graph).to receive(:breadth_first_search).never
 
-      expect(complete_undirected_graph).not_to be_bipartite
+      expect(complete_graph).not_to be_bipartite
     end
 
     it 'returns true if the graph is an even cycle' do
@@ -74,7 +61,7 @@ describe Math::Discrete::Graph::Properties do
     let(:completeness) { Graph::Properties.completeness }
 
     it 'returns true if and only if every vertex is adjacent to every other vertex in the graph' do
-      expect(complete_undirected_graph.satisfies? completeness).to be true
+      expect(complete_graph.satisfies? completeness).to be true
     end
 
     it 'returns false if there is a vertex that is not adjacent to all other vertices in the graph' do

--- a/spec/graph/properties_spec.rb
+++ b/spec/graph/properties_spec.rb
@@ -21,7 +21,7 @@ describe Math::Discrete::Graph::Properties do
       end
 
       it 'defines a valid Property object for graphs' do
-        expect(Graph::Properties.send(property_method)).to be_a Math::Discrete::Property
+        expect(Graph::Properties.send(property_method)).to be_an_instance_of Math::Discrete::Property
         expect(Graph::Properties.send(property_method).structure_type).to be :graph
       end
     end
@@ -29,8 +29,8 @@ describe Math::Discrete::Graph::Properties do
 
   describe '::all' do
     it 'returns a Set of Property objects' do
-      expect(described_class.all).to be_a Array
-      expect(described_class.all).to all be_a Math::Discrete::Property
+      expect(described_class.all).to be_an_instance_of Array
+      expect(described_class.all).to all be_an_instance_of Math::Discrete::Property
       expect(described_class.map(&:structure_type)).to all be :graph
     end
   end

--- a/spec/graph/vertex_spec.rb
+++ b/spec/graph/vertex_spec.rb
@@ -5,7 +5,7 @@ describe Math::Discrete::Graph::Vertex do
 
   describe '::[]' do
     it 'creates a new vertex with the given label and no adjacent vertices' do
-      expect(vertex).to be_a Vertex
+      expect(vertex).to be_an_instance_of Vertex
       expect(vertex.label).to eq 'A'
       expect(vertex.adjacent_vertices).to be_empty
     end
@@ -15,8 +15,8 @@ describe Math::Discrete::Graph::Vertex do
     let(:vertices) { Vertex::Set['A', 'B', 'C'] }
 
     it 'creates a Set of vertices with the given labels and no adjacent vertices' do
-      expect(vertices).to be_a Set
-      expect(vertices).to all be_a Vertex
+      expect(vertices).to be_an_instance_of Set
+      expect(vertices).to all be_an_instance_of Vertex
       expect(vertices.map &:label).to contain_exactly 'A', 'B', 'C'
       expect(vertices.map &:adjacent_vertices).to all be_empty
     end
@@ -35,7 +35,7 @@ describe Math::Discrete::Graph::Vertex do
     let(:other_vertex) { Vertex['other'] }
 
     it 'removes the given vertex from the vertex\'s set of adjacent vertices' do
-      vertex.send :add_adjacent_vertex, other_vertex, 1
+      vertex.send :add_adjacent_vertex, other_vertex
 
       expect { vertex.send :remove_adjacent_vertex, other_vertex }.to change(vertex.adjacent_vertices, :count).by(-1)
       expect(vertex.adjacent_vertices).not_to include other_vertex
@@ -46,7 +46,7 @@ describe Math::Discrete::Graph::Vertex do
     let(:other_vertex) { Vertex['other'] }
 
     it 'returns true if the other vertex is part of the vertex\'s set of adjacent vertices' do
-      vertex.send :add_adjacent_vertex, other_vertex, 1
+      vertex.send :add_adjacent_vertex, other_vertex
 
       expect(vertex).to be_adjacent_to other_vertex
     end
@@ -57,6 +57,24 @@ describe Math::Discrete::Graph::Vertex do
 
     it 'raises a TypeError if the input is an object of a non-Vertex type' do
       expect { vertex.adjacent_to? 'This is not a vertex' }.to raise_error TypeError
+    end
+  end
+
+  describe '#distance_to' do
+    let(:vertex) { Vertex[1] }
+    let(:other_vertex) do
+      other_vertex = Vertex[2]
+      vertex.send :add_adjacent_vertex, other_vertex, 5
+
+      other_vertex
+    end
+
+    it 'raises a VertexNotFound if the other vertex is not part of the graph\'s vertex set' do
+      expect { vertex.distance_to Vertex[3] }.to raise_error Graph::VertexNotFound
+    end
+
+    it 'returns the weight of the edge to the other vertex' do
+      expect(vertex.distance_to other_vertex).to be 5
     end
   end
 

--- a/spec/graph/vertex_spec.rb
+++ b/spec/graph/vertex_spec.rb
@@ -1,40 +1,41 @@
 require 'spec_helper'
 
 describe Math::Discrete::Graph::Vertex do
-  let(:vertex) { described_class.build_from_label 'A' }
+  let(:vertex) { Vertex['A'] }
 
-  describe '::build_from_label' do
+  describe '::[]' do
     it 'creates a new vertex with the given label and no adjacent vertices' do
-      expect(vertex).to be_a described_class
+      expect(vertex).to be_a Vertex
       expect(vertex.label).to eq 'A'
       expect(vertex.adjacent_vertices).to be_empty
     end
   end
 
-  describe '::build_from_labels' do
-    let(:vertices) { described_class.build_from_labels 'A', 'B', 'C' }
+  describe '::Set::[]' do
+    let(:vertices) { Vertex::Set['A', 'B', 'C'] }
 
     it 'creates a Set of vertices with the given labels and no adjacent vertices' do
       expect(vertices).to be_a Set
+      expect(vertices).to all be_a Vertex
       expect(vertices.map &:label).to contain_exactly 'A', 'B', 'C'
       expect(vertices.map &:adjacent_vertices).to all be_empty
     end
   end
 
   describe '#add_adjacent_vertex' do
-    let(:other_vertex) { described_class.build_from_label 'other' }
+    let(:other_vertex) { Vertex['other'] }
 
     it 'adds the given vertex to the vertex\'s set of adjacent vertices' do
-      expect { vertex.send :add_adjacent_vertex, other_vertex }.to change(vertex.adjacent_vertices, :count).by(1)
+      expect { vertex.send :add_adjacent_vertex, other_vertex, 1 }.to change(vertex.adjacent_vertices, :count).by(1)
       expect(vertex.adjacent_vertices).to include other_vertex
     end
   end
 
   describe '#remove_adjacent_vertex' do
-    let(:other_vertex) { described_class.build_from_label 'other' }
+    let(:other_vertex) { Vertex['other'] }
 
     it 'removes the given vertex from the vertex\'s set of adjacent vertices' do
-      vertex.send :add_adjacent_vertex, other_vertex
+      vertex.send :add_adjacent_vertex, other_vertex, 1
 
       expect { vertex.send :remove_adjacent_vertex, other_vertex }.to change(vertex.adjacent_vertices, :count).by(-1)
       expect(vertex.adjacent_vertices).not_to include other_vertex
@@ -42,10 +43,10 @@ describe Math::Discrete::Graph::Vertex do
   end
 
   describe '#adjacent_to?' do
-    let(:other_vertex) { described_class.build_from_label 'other' }
+    let(:other_vertex) { Vertex['other'] }
 
     it 'returns true if the other vertex is part of the vertex\'s set of adjacent vertices' do
-      vertex.send :add_adjacent_vertex, other_vertex
+      vertex.send :add_adjacent_vertex, other_vertex, 1
 
       expect(vertex).to be_adjacent_to other_vertex
     end
@@ -55,13 +56,13 @@ describe Math::Discrete::Graph::Vertex do
     end
 
     it 'raises a TypeError if the input is an object of a non-Vertex type' do
-      expect { vertex.adjacent_to? 'This is not a vertex' }.to raise_error Math::Discrete::TypeError
+      expect { vertex.adjacent_to? 'This is not a vertex' }.to raise_error TypeError
     end
   end
 
   describe '#==' do
-    let(:same_vertex) { described_class.build_from_label 'A' }
-    let(:different_vertex) { described_class.build_from_label 'B'}
+    let(:same_vertex) { Vertex['A'] }
+    let(:different_vertex) { Vertex['B'] }
 
     it 'returns true if compared with itself' do
       expect(vertex).to eq vertex
@@ -78,7 +79,7 @@ describe Math::Discrete::Graph::Vertex do
     end
 
     it 'raises a TypeError when compared to an object of non-Vertex type' do
-      expect { vertex == 'This is not a vertex' }.to raise_error Math::Discrete::TypeError
+      expect { vertex == 'This is not a vertex' }.to raise_error TypeError
     end
   end
 end

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -36,18 +36,18 @@ describe Math::Discrete::Property do
     end
 
     it 'raises a TypeError if the method is called with a structure of the wrong type' do
-      expect { property.satisfied? 'This is not a graph.' }.to raise_error Math::Discrete::TypeError
+      expect { property.satisfied? 'This is not a graph.' }.to raise_error TypeError
     end
 
     it 'raises a TypeError if the satisfiability_test returns a non-Boolean result' do
       graph = Graph.build
 
-      expect { bad_property.satisfied? graph }.to raise_error Math::Discrete::TypeError
+      expect { bad_property.satisfied? graph }.to raise_error TypeError
     end
 
     it 'returns the result of the satisfiability_test if the structure and result types are correct' do
-      graph = Graph.build_from_labels vertex_labels: Set['a', 'b'], edge_labels: Set[%w(a b)]
-      other_graph = Graph.build_from_labels vertex_labels: Set['a', 'b', 'c'], edge_labels: Set[%w(a b), %w(b c)]
+      graph = Graph[['a', 'b'], [%w(a b)]]
+      other_graph = Graph[['a', 'b', 'c'], [%w(a b), %w(b c)]]
 
       expect(property).to be_satisfied(graph)
       expect(property).not_to be_satisfied(other_graph)


### PR DESCRIPTION
__Goal__
Implement a `Graph::Path` class and shortest path algorithms.

Note: for shortest paths, implement both Bellman-Ford and Dijkstra since Dijkstra does not work for graphs with negative weights.

__Testing Dijkstra's Algorithm__
Here's the test graph:
![](https://upload.wikimedia.org/wikipedia/commons/5/57/Dijkstra_Animation.gif)

```ruby
g = Graph[[1,2,3,4,5,6], [[1,2,7],[2,1,7],[1,6,14],[6,1,14],[1,3,9],[3,1,9],[2,3,10],[3,2,10],[3,6,2],[6,3,2],[3,4,11],[4,3,11],[2,4,15],[4,2,15],[4,5,6],[5,4,6],[6,5,9],[5,6,9]]]

source, target = g.find_vertices_by_labels!(1, 5).to_a

g.shortest_path_between source: source, target: target
=> {1=>{:distance=>0, :parent=>nil}, 2=>{:distance=>7, :parent=>1}, 3=>{:distance=>9, :parent=>1}, 4=>{:distance=>20, :parent=>3}, 5=>{:distance=>23, :parent=>6}, 6=>{:distance=>11, :parent=>3}}
```
