### PR TITLE
Add contant time access for Graphs and Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Structures:
 - [ ] Set Comprehensions (for sets of all other constructs)
 - [ ] Logic Propositions (first-order and second-order)
 - [x] Graphs
-- [ ] Graph Constructs (paths)
+- [x] Graph Constructs (paths)
 - [ ] Natural numbers and Integer numbers
 - [ ] Mappings (injections, surjections, bijections between two sets)
 

--- a/lib/math/discrete/graph.rb
+++ b/lib/math/discrete/graph.rb
@@ -61,21 +61,26 @@ class Math::Discrete::Graph
       raise TypeError, 'vertex_labels must be of type Set' unless vertex_labels.is_a? Set
       raise TypeError, 'edge_labels must be of type Set' unless edge_labels.is_a? Set
 
-      vertices = Vertex::Set[*vertex_labels]
+      graph = new
 
-      edges = edge_labels.map do |label_set|
-        from = vertices.find { |vertex| vertex.label == label_set.first }
-        to = vertices.find { |vertex| vertex.label == label_set.to_a[1] }
-        weight = label_set.to_a[2] || 1
+      graph.send :add_vertices!, Vertex::Set[*vertex_labels]
 
-        raise VertexNotFound, "could not find a vertex with label=#{ label_set.first }" if from.nil?
-        raise VertexNotFound, "could not find a vertex with label=#{ label_set.to_a.last }" if to.nil?
+      edge_labels.each do |label_set|
+        from_label, to_label, weight = label_set.entries
+
+        from = graph[from_label]
+        raise VertexNotFound, "could not find a vertex with label=#{ from_label }" if from.nil?
+
+        to = graph[to_label]
+        raise VertexNotFound, "could not find a vertex with label=#{ to_label }" if to.nil?
+
+        weight ||= 1
         raise TypeError, 'edge weight must be of a Numeric type' unless weight.is_a? Numeric
 
-        Edge[from, to, weight]
+        graph.add_edge! Edge[from, to, weight]
       end
 
-      build_from_sets vertex_set: Set[*vertices], edge_set: Set[*edges]
+      graph
     end
   end
 

--- a/lib/math/discrete/graph.rb
+++ b/lib/math/discrete/graph.rb
@@ -51,8 +51,8 @@ class Math::Discrete::Graph
 
       graph = new
 
-      graph.add_vertices! vertex_set
-      graph.add_edges! edge_set
+      graph.send :add_vertices!, vertex_set
+      graph.send :add_edges!, edge_set
 
       graph
     end
@@ -86,7 +86,51 @@ class Math::Discrete::Graph
   end
 
   def <<(vertex_or_edge)
+    case vertex_or_edge
+    when Edge
+      add_edge! vertex_or_edge
+    when Vertex
+      add_vertex! vertex_or_edge
+    else
+      raise TypeError, 'input must be of type Edge or Vertex'
+    end
+  end
 
+  def vertex_set
+    @vertex_map.values.to_set
+  end
+  alias_method :node_set, :vertex_set
+
+  def edge_set
+    @edge_map.values.to_set
+  end
+
+  def vertex_labels
+    @vertex_map.keys.to_set
+  end
+  alias_method :node_labels, :vertex_labels
+
+  def edge_labels
+    edge_set.map(&:labels).to_set
+  end
+
+  def weighted?
+    edge_set.any? &:weighted?
+  end
+
+  def satisfies?(property)
+    property_name = property.name.to_sym
+
+    return @properties[property_name] unless @properties[property_name].nil?
+
+    @properties[property_name] = property.satisfied? self
+    @properties.fetch property_name
+  end
+
+  def determine_properties!(properties = Properties::all)
+    properties.map { |property| satisfies? property }
+
+    @properties
   end
 
   def add_vertex!(vertex)
@@ -166,43 +210,6 @@ class Math::Discrete::Graph
     raise EdgeNotFound, "could not find a edge with labels=(#{ from_label },#{ to_label })" if result.nil?
 
     result
-  end
-
-  def vertex_set
-    @vertex_map.values.to_set
-  end
-  alias_method :node_set, :vertex_set
-
-  def edge_set
-    @edge_map.values.to_set
-  end
-
-  def vertex_labels
-    @vertex_map.keys.to_set
-  end
-  alias_method :node_labels, :vertex_labels
-
-  def edge_labels
-    edge_set.map(&:labels).to_set
-  end
-
-  def weighted?
-    edge_set.any? &:weighted?
-  end
-
-  def satisfies?(property)
-    property_name = property.name.to_sym
-
-    return @properties[property_name] unless @properties[property_name].nil?
-
-    @properties[property_name] = property.satisfied? self
-    @properties.fetch property_name
-  end
-
-  def determine_properties!(properties = Properties::all)
-    properties.map { |property| satisfies? property }
-
-    @properties
   end
 
   private

--- a/lib/math/discrete/graph/algorithms.rb
+++ b/lib/math/discrete/graph/algorithms.rb
@@ -66,7 +66,7 @@ module Math::Discrete::Graph::Algorithms
 
     return Graph::Path[] if source == target
 
-    distance_tree = if @edge_set.map(&:weight).all? { |weight| weight > 0 }
+    distance_tree = if edge_set.map(&:weight).all? { |weight| weight > 0 }
       dijkstras_algorithm(source, target)
     else
       bellman_fords_algorithm(source, target)
@@ -123,7 +123,7 @@ module Math::Discrete::Graph::Algorithms
     end
 
     (vertex_set.size - 1).times do
-      @edge_set.each do |edge|
+      edge_set.each do |edge|
         alt = distance_tree[edge.from.label][:distance] + edge.weight
 
         if alt < distance_tree[edge.to.label][:distance]
@@ -132,7 +132,7 @@ module Math::Discrete::Graph::Algorithms
       end
     end
 
-    @edge_set.each do |edge|
+    edge_set.each do |edge|
       if distance_tree[edge.from.label][:distance] + edge.weight < distance_tree[edge.to.label][:distance]
         raise NegativeWeightCycleError, 'the graph contains a negative-weight cycle'
       end

--- a/lib/math/discrete/graph/edge.rb
+++ b/lib/math/discrete/graph/edge.rb
@@ -3,44 +3,25 @@ class Math::Discrete::Graph::Edge
   attr_accessor :weight
 
   private_class_method :new
-  def initialize(from: , to:, directed: true, weight: 1)
+  def initialize(from: , to:, weight: 1)
     raise TypeError, 'from must be of type Math::Discrete::Graph::Vertex' unless from.is_a? Vertex
     raise TypeError, 'to must be of type Math::Discrete::Graph::Vertex' unless to.is_a? Vertex
-    raise TypeError, 'directed must be of a Boolean type' unless !!directed == directed
     raise TypeError, 'weight must be of a Numeric type' unless weight.is_a? Numeric
 
     @from = from
     @to = to
-    @directed = directed
     @weight = weight
 
     @from.send :add_adjacent_vertex, @to, weight
-    @to.send :add_adjacent_vertex, @from, weight unless directed
   end
 
-  module Undirected
-    def self.[](from, to, weight = 1)
-      Edge.send :new, directed: false, from: from, to: to, weight: weight
-    end
-  end
-
-  module Directed
-    def self.[](from, to, weight = 1)
-      Edge.send :new, directed: true, from: from, to: to, weight: weight
-    end
+  def self.[](from, to, weight = 1)
+    Edge.send :new, from: from, to: to, weight: weight
   end
 
   module Set
-    module Undirected
-      def self.[](*edges)
-        edges.map { |edge| Edge::Undirected[*edge] }.to_set
-      end
-    end
-
-    module Directed
-      def self.[](*edges)
-        edges.map { |edge| Edge::Directed[*edge] }.to_set
-      end
+    def self.[](*edges)
+      edges.map { |edge| Edge[*edge] }.to_set
     end
   end
 
@@ -53,16 +34,7 @@ class Math::Discrete::Graph::Edge
   end
 
   def ==(other_edge)
-    return false unless directed? == other_edge.directed?
-    return from == other_edge.from && to == other_edge.to if directed?
-    return true if from == other_edge.from && to == other_edge.to
-    return true if from == other_edge.to && to == other_edge.from
-
-    false
-  end
-
-  def directed?
-    @directed
+    from == other_edge.from && to == other_edge.to
   end
 
   def weighted?

--- a/lib/math/discrete/graph/path.rb
+++ b/lib/math/discrete/graph/path.rb
@@ -1,11 +1,10 @@
 class Math::Discrete::Graph::Path
   class InvalidPath < StandardError; end
 
-  attr_reader :edges
-
   private_class_method :new
   def initialize(edges = Set[])
-    @edges = edges
+    @edge_map = edges.map { |e| [[e.from.label, e.to.label], e] }.to_h
+    @vertex_map = vertices.map { |v| [v.label, v] }.to_h
   end
 
   def self.[](*edges)
@@ -15,23 +14,19 @@ class Math::Discrete::Graph::Path
   end
 
   def cyclical?
-    return false if @edges.empty?
+    return false if @edge_map.empty?
 
-    labels.first.first == labels.to_a.last.to_a.last
+    @edge_map.values.first.from == @edge_map.values.last.to
   end
 
-  def labels
-    Set[*@edges.map(&:labels)]
+  def edges
+    Set[*@edge_map.values]
   end
 
   def vertices
-    Set[*@edges.map(&:vertices).reduce(&:+)]
+    Set[*@edge_map.values.map(&:vertices).reduce(&:+)]
   end
   alias_method :nodes, :vertices
-
-  def length
-    @edges.size
-  end
 
   private
 

--- a/lib/math/discrete/graph/properties.rb
+++ b/lib/math/discrete/graph/properties.rb
@@ -56,7 +56,7 @@ module Math::Discrete::Graph::Properties
         n = graph.vertex_set.size
         m = graph.edge_set.size
 
-        m == (n * (n - 1)) / (graph.directed? ? 1 : 2)
+        m == (n * (n - 1))
       end
     end
 

--- a/spec/graph/algorithms_spec.rb
+++ b/spec/graph/algorithms_spec.rb
@@ -1,23 +1,22 @@
 require 'spec_helper'
 
 describe Graph::Algorithms do
-  let(:empty_directed_graph) { Graph[] }
-  let(:empty_undirected_graph) { Graph.build directed: false }
-  let(:directed_graph) { Graph[[1,2,3,4], [[1,2],[2,3],[3,1], [1,4], [4,2]]] }
+  let(:empty_graph) { Graph[] }
+  let(:graph) { Graph[[1,2,3,4], [[1,2],[2,3],[3,1], [1,4], [4,2]]] }
   let(:foreign_vertex) { Vertex['Z'] }
 
   describe '#breadth_first_search' do
-    let(:search_tree) { directed_graph.breadth_first_search }
+    let(:search_tree) { graph.breadth_first_search }
 
     it 'returns an empty search tree if the graph is empty' do
-      expect(empty_directed_graph.breadth_first_search).to be_an_instance_of Hash
-      expect(empty_directed_graph.breadth_first_search).to be_empty
+      expect(empty_graph.breadth_first_search).to be_an_instance_of Hash
+      expect(empty_graph.breadth_first_search).to be_empty
     end
 
     it 'returns a valid search tree in Hash form' do
       expect(search_tree).to be_an_instance_of Hash
       expect(search_tree).not_to be_empty
-      expect(search_tree.keys).to contain_exactly *directed_graph.vertex_labels
+      expect(search_tree.keys).to contain_exactly *graph.vertex_labels
     end
 
     it 'satisfies the properties of a BFS tree' do
@@ -41,40 +40,40 @@ describe Graph::Algorithms do
 
     it 'raises a TypeError if the root is not a Vertex' do
       expect {
-        directed_graph.breadth_first_search root: 'not_a_vertex'
+        graph.breadth_first_search root: 'not_a_vertex'
       }.to raise_error TypeError
     end
 
     it 'raises a VertexNotFound if the root is not in the graph' do
       expect {
-        directed_graph.breadth_first_search root: foreign_vertex
+        graph.breadth_first_search root: foreign_vertex
       }.to raise_error Graph::VertexNotFound
     end
   end
 
   describe '#depth_first_search' do
-    let(:search_tree) { directed_graph.depth_first_search }
+    let(:search_tree) { graph.depth_first_search }
 
     it 'returns an empty search tree if the graph is empty' do
-      expect(empty_directed_graph.depth_first_search).to be_an_instance_of Hash
-      expect(empty_directed_graph.depth_first_search).to be_empty
+      expect(empty_graph.depth_first_search).to be_an_instance_of Hash
+      expect(empty_graph.depth_first_search).to be_empty
     end
 
     it 'returns a valid search tree in Hash form' do
       expect(search_tree).to be_an_instance_of Hash
       expect(search_tree).not_to be_empty
-      expect(search_tree.keys).to contain_exactly *directed_graph.vertex_labels
+      expect(search_tree.keys).to contain_exactly *graph.vertex_labels
     end
 
     it 'raises a TypeError if the root is not a Vertex' do
       expect {
-        directed_graph.depth_first_search root: 'not_a_vertex'
+        graph.depth_first_search root: 'not_a_vertex'
       }.to raise_error TypeError
     end
 
     it 'raises a VertexNotFound if the root is not in the graph' do
       expect {
-        directed_graph.depth_first_search root: foreign_vertex
+        graph.depth_first_search root: foreign_vertex
       }.to raise_error Graph::VertexNotFound
     end
   end

--- a/spec/graph/edge_spec.rb
+++ b/spec/graph/edge_spec.rb
@@ -3,79 +3,48 @@ require 'spec_helper'
 describe Math::Discrete::Graph::Edge do
   let(:first_vertex) { Vertex['A'] }
   let(:second_vertex) { Vertex['B'] }
-  let(:directed_edge) { Edge::Directed[first_vertex, second_vertex] }
-  let(:undirected_edge) { Edge::Undirected[first_vertex, second_vertex] }
+  let(:edge) { Edge[first_vertex, second_vertex] }
 
-  context '::Directed' do
-    describe '::build' do
-      it 'creates a new edge between the two given vertices' do
-        expect(directed_edge.from).to be first_vertex
-        expect(directed_edge.to).to be second_vertex
-      end
-
-      it 'connects the vertices and updates their set of adjacent vertices' do
-        expect(directed_edge.from.adjacent_vertices).to include directed_edge.to
-        expect(directed_edge.to.adjacent_vertices).to be_empty
-      end
-
-      it 'raises a TypeError when given objects of non-Vertex type as input' do
-        expect { Edge::Directed['Not a vertex', second_vertex] }.to raise_error TypeError
-        expect { Edge::Directed[first_vertex, 'Not a vertex'] }.to raise_error TypeError
-      end
-
-      it 'raises a TypeError when given a non-numeric weight' do
-        expect { Edge::Directed['Not a vertex', second_vertex, '1'] }.to raise_error TypeError
-      end
+  describe '::build' do
+    it 'creates a new edge between the two given vertices' do
+      expect(edge.from).to be first_vertex
+      expect(edge.to).to be second_vertex
     end
-  end
 
-  context '::Undirected' do
-    describe '::build_between' do
-      it 'creates a new edge between the two given vertices' do
-        expect(undirected_edge.from).to be first_vertex
-        expect(undirected_edge.to).to be second_vertex
-      end
+    it 'connects the vertices and updates their set of adjacent vertices' do
+      expect(edge.from.adjacent_vertices).to include edge.to
+      expect(edge.to.adjacent_vertices).to be_empty
+    end
 
-      it 'connects the vertices and updates their set of adjacent vertices' do
-        expect(undirected_edge.from.adjacent_vertices).to include undirected_edge.to
-        expect(undirected_edge.to.adjacent_vertices).to include undirected_edge.from
-      end
+    it 'raises a TypeError when given objects of non-Vertex type as input' do
+      expect { Edge['Not a vertex', second_vertex] }.to raise_error TypeError
+      expect { Edge[first_vertex, 'Not a vertex'] }.to raise_error TypeError
+    end
 
-      it 'raises a TypeError when given objects of non-Vertex type as input' do
-        expect { Edge::Undirected['Not a vertex', second_vertex] }.to raise_error TypeError
-        expect { Edge::Undirected[first_vertex, 'Not a vertex'] }.to raise_error TypeError
-      end
-
-      it 'raises a TypeError when given a non-numeric weight' do
-        expect { Edge::Undirected['Not a vertex', second_vertex, '1'] }.to raise_error TypeError
-      end
+    it 'raises a TypeError when given a non-numeric weight' do
+      expect { Edge['Not a vertex', second_vertex, '1'] }.to raise_error TypeError
     end
   end
 
   describe '#==' do
-    let(:third_vertex) { Vertex['B'] }
-    let(:same_undirected_edge) { Edge::Undirected[second_vertex, first_vertex] }
-    let(:same_directed_edge) { Edge::Directed[first_vertex, second_vertex] }
+    let(:same_edge) { Edge[first_vertex, second_vertex] }
+    let(:third_vertex) { Vertex['C'] }
+    let(:different_edge) { Edge[second_vertex, third_vertex] }
 
-    it 'returns false when undirected and other_edge is directed or vice versa' do
-      expect(directed_edge).not_to eq undirected_edge
-      expect(undirected_edge).not_to eq directed_edge
+    it 'returns false the other edge does not have the same vertices' do
+      expect(edge).not_to eq different_edge
+      expect(different_edge).not_to eq edge
     end
 
-    it 'returns true if both edges are directed, originate from the same vertex and end at the same vertex' do
-      expect(same_directed_edge).to eq directed_edge
-      expect(directed_edge).to eq same_directed_edge
-    end
-
-    it 'returns true if both edges are undirected and between the same vertices' do
-      expect(undirected_edge).to eq same_undirected_edge
-      expect(same_undirected_edge).to eq undirected_edge
+    it 'returns true if both edges are between the same vertices' do
+      expect(edge).to eq same_edge
+      expect(same_edge).to eq edge
     end
   end
 
   describe '#labels' do
     it 'returns a set of labels of the vertices connected by the edge' do
-      labels = directed_edge.labels
+      labels = edge.labels
 
       expect(labels).to be_an_instance_of Set
       expect(labels).to contain_exactly 'A', 'B'
@@ -84,7 +53,7 @@ describe Math::Discrete::Graph::Edge do
 
   describe '#vertices' do
     it 'returns a set of the vertices connected by the edge' do
-      vertices = directed_edge.vertices
+      vertices = edge.vertices
 
       expect(vertices).to be_an_instance_of Set
       expect(vertices).to contain_exactly first_vertex, second_vertex
@@ -93,13 +62,13 @@ describe Math::Discrete::Graph::Edge do
 
   describe '#weighted?' do
     it 'returns true if the weight is different from 1' do
-      directed_edge.weight = 2
+      edge.weight = 2
 
-      expect(directed_edge).to be_weighted
+      expect(edge).to be_weighted
     end
 
     it 'returns false if the weight is equal to 1' do
-      expect(undirected_edge).not_to be_weighted
+      expect(edge).not_to be_weighted
     end
   end
 end

--- a/spec/graph/graph_spec.rb
+++ b/spec/graph/graph_spec.rb
@@ -5,22 +5,16 @@ describe Math::Discrete::Graph do
 
   describe '::[]' do
     let(:vertex_set) { Vertex::Set['A', 'B', 'C'] }
-    let(:directed_edge_set) do
-      Edge::Set::Directed[
+    let(:edge_set) do
+      Edge::Set[
         [vertex_set.entries[0], vertex_set.entries[1]],
         [vertex_set.entries[1], vertex_set.entries[0]],
         [vertex_set.entries[1], vertex_set.entries[2]],
         [vertex_set.entries[2], vertex_set.entries[1]]
       ]
     end
-    let(:undirected_edge_set) do
-      Edge::Set::Undirected[
-        [vertex_set.entries[0], vertex_set.entries[1]],
-        [vertex_set.entries[1], vertex_set.entries[2]],
-      ]
-    end
-    let(:directed_graph_from_sets) { Graph[vertex_set, directed_edge_set] }
-    let(:undirected_graph_from_sets) { Graph[vertex_set, undirected_edge_set] }
+
+    let(:graph_from_sets) { Graph[vertex_set, edge_set] }
     let(:graph_from_labels) { Graph[[1, 2, 3], [[1, 2], [2, 3], [3, 1], [1, 3]]] }
 
     it 'raises a TypeError if the given vertex set or label set is not a Set or an Array' do
@@ -36,23 +30,14 @@ describe Math::Discrete::Graph do
     end
 
     it 'builds a graph from the given vertex set and edge set' do
-      expect(directed_graph_from_sets).to be_an_instance_of Graph
-      expect(directed_graph_from_sets.vertex_set).to eq vertex_set
-      expect(directed_graph_from_sets.edge_set).to eq directed_edge_set
+      expect(graph_from_sets).to be_an_instance_of Graph
+      expect(graph_from_sets.vertex_set).to eq vertex_set
+      expect(graph_from_sets.edge_set).to eq edge_set
     end
 
-    it 'builds a directed graph from the given vertex label set and edge label set' do
+    it 'builds a graph from the given vertex label set and edge label set' do
       expect(graph_from_labels).to be_an_instance_of Graph
-      expect(graph_from_labels).to be_directed
       expect(graph_from_labels.vertex_labels).to contain_exactly 1, 2, 3
-    end
-
-    it 'builds a directed or undirected graph based on the edge set' do
-      expect(directed_edge_set).to all be_directed
-      expect(directed_graph_from_sets).to be_directed
-
-      expect(undirected_edge_set).to all satisfy { |edge| !edge.directed? }
-      expect(undirected_graph_from_sets).not_to be_directed
     end
   end
 
@@ -106,74 +91,54 @@ describe Math::Discrete::Graph do
 
   describe '#add_edge!' do
     let(:vertices) { Vertex::Set[*labels] }
-    let(:directed_graph) { Graph[vertices, []] }
-    let(:undirected_graph) { Graph.build directed: false }
-    let(:directed_edge) { Edge::Directed[*vertices] }
-    let(:undirected_edge) { Edge::Undirected[*vertices] }
+    let(:graph) { Graph[vertices, []] }
+    let(:edge) { Edge[*vertices] }
 
     it 'adds the edge to the edge set' do
-      directed_graph.add_edge! directed_edge
-      expect(directed_graph.edge_set).to include directed_edge
+      graph.add_edge! edge
+      expect(graph.edge_set).to include edge
     end
 
     it 'raises a TypeError if the input is an object of a non-Edge type' do
       expect {
-        directed_graph.add_edge! 'This is not an edge'
+        graph.add_edge! 'This is not an edge'
       }.to raise_error TypeError
     end
 
     it 'raises a EdgeNotUnique if the edge is already part of the edge set' do
-      directed_graph.add_edge! directed_edge
+      graph.add_edge! edge
 
-      expect { directed_graph.add_edge! directed_edge }.to raise_error Graph::EdgeNotUnique
-    end
-
-    it 'raises a BadEdgeType if the edge is directed and the graph is undirected' do
-      expect { undirected_graph.add_edge! directed_edge }.to raise_error Graph::BadEdgeType
-    end
-
-    it 'raises a BadEdgeType if the edge is undirected and the graph is directed' do
-      expect { directed_graph.add_edge! undirected_edge }.to raise_error Graph::BadEdgeType
+      expect { graph.add_edge! edge }.to raise_error Graph::EdgeNotUnique
     end
   end
 
   describe '#add_edges!' do
     let(:vertices) { Vertex::Set[*labels] }
-    let(:directed_graph) { Graph[vertices] }
-    let(:undirected_graph) { Graph.build directed: false }
-    let(:directed_edges) { Edge::Set::Directed[[*vertices]] }
-    let(:undirected_edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:graph) { Graph[vertices] }
+    let(:edges) { Edge::Set[[*vertices]] }
 
     it 'adds the edges to the edge set' do
-      directed_graph.add_edges! directed_edges
-      expect(directed_graph.edge_set).to include *directed_edges
+      graph.add_edges! edges
+      expect(graph.edge_set).to include *edges
     end
 
     it 'raises a TypeError if the input includes an object of a non-Edge type' do
       expect {
-        directed_graph.add_edges!(directed_edges << 'This is not an edge')
+        graph.add_edges!(edges << 'This is not an edge')
       }.to raise_error TypeError
     end
 
     it 'raises a EdgeNotUnique if the input includes an edge that is already part of the edge set' do
-      directed_graph.add_edge! directed_edges.first
+      graph.add_edge! edges.first
 
-      expect { directed_graph.add_edges! directed_edges }.to raise_error Graph::EdgeNotUnique
-    end
-
-    it 'raises a BadEdgeType if the edge is directed and the graph is undirected' do
-      expect { undirected_graph.add_edges! directed_edges }.to raise_error Graph::BadEdgeType
-    end
-
-    it 'raises a BadEdgeType if the edge is undirected and the graph is directed' do
-      expect { directed_graph.add_edges! undirected_edges }.to raise_error Graph::BadEdgeType
+      expect { graph.add_edges! edges }.to raise_error Graph::EdgeNotUnique
     end
   end
 
   describe '#remove_vertex!, #remove_node!' do
     let(:vertices) { Vertex::Set[*labels] }
     let(:vertex) { vertices.first }
-    let(:edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:edges) { Edge::Set[[*vertices]] }
     let(:edge) { edges.first }
     let(:graph) { Graph[vertices, edges] }
 
@@ -203,7 +168,7 @@ describe Math::Discrete::Graph do
   describe '#remove_vertices!, #remove_nodes!' do
     let(:vertices) { Vertex::Set[*labels] }
     let(:vertex) { vertices.first }
-    let(:edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:edges) { Edge::Set[[*vertices]] }
     let(:edge) { edges.first }
     let(:graph) { Graph[vertices, edges] }
 
@@ -232,7 +197,7 @@ describe Math::Discrete::Graph do
 
   describe '#remove_edge!' do
     let(:vertices) { Vertex::Set[*labels] }
-    let(:edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:edges) { Edge::Set[[*vertices]] }
     let(:edge) { edges.first }
     let(:graph) { Graph[vertices, edges] }
 
@@ -248,7 +213,7 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises an EdgeNotFound if the input is an edge that is not part of the edge set' do
-      foreign_edge = Edge::Undirected[*vertices]
+      foreign_edge = Edge[*vertices]
 
       expect { graph.remove_edge! foreign_edge }.to raise_error Graph::EdgeNotFound
     end
@@ -256,7 +221,7 @@ describe Math::Discrete::Graph do
 
   describe '#remove_edges!' do
     let(:vertices) { Vertex::Set[*labels] }
-    let(:edges) { Edge::Set::Undirected[[*vertices]] }
+    let(:edges) { Edge::Set[[*vertices]] }
     let(:edge) { edges.first }
     let(:graph) { Graph[vertices, edges] }
 
@@ -272,7 +237,7 @@ describe Math::Discrete::Graph do
     end
 
     it 'raises an EdgeNotFound if the input includes an edge that is not part of the edge set' do
-      foreign_edge = Edge::Undirected[*vertices]
+      foreign_edge = Edge[*vertices]
 
       expect { graph.remove_edges! [foreign_edge] }.to raise_error Graph::EdgeNotFound
     end
@@ -313,30 +278,18 @@ describe Math::Discrete::Graph do
 
   describe '#find_edge_by_labels!' do
     let(:vertices) { Vertex::Set[*labels] }
-    let(:directed_edges) { Edge::Set::Directed[[*vertices]] }
-    let(:directed_edge) { directed_edges.first }
-    let(:undirected_edges) { Edge::Set::Undirected[[*vertices]] }
-    let(:undirected_edge) { undirected_edges.first }
-    let(:directed_graph) { Graph[vertices, directed_edges] }
-    let(:undirected_graph) { Graph[vertices, undirected_edges] }
-    let(:directed_result) { directed_graph.find_edge_by_labels! *labels }
-    let(:undirected_result) { undirected_graph.find_edge_by_labels! *labels.entries.reverse }
+    let(:edges) { Edge::Set[[*vertices]] }
+    let(:edge) { edges.first }
+    let(:graph) { Graph[vertices, edges] }
+    let(:result) { graph.find_edge_by_labels! *labels }
 
-    it 'returns the directed edge with the given labels in order in the edge set' do
-      expect(directed_result).to be_an_instance_of Edge
-      expect(directed_result).to be_directed
-      expect(directed_result.labels).to contain_exactly *labels
-    end
-
-    it 'returns the undirected edge with the given labels regardless of order in the edge set' do
-      expect(undirected_edge).to be_an_instance_of Edge
-      expect(undirected_edge).not_to be_directed
-      expect(undirected_result.labels).to contain_exactly *labels
+    it 'returns the edge with the given labels in order in the edge set' do
+      expect(result).to be_an_instance_of Edge
+      expect(result.labels).to contain_exactly *labels
     end
 
     it 'raises EdgeNotFound if the edge set does not include an edge with the given labels' do
-      expect { directed_graph.find_edge_by_labels! 'X', 'Y' }.to raise_error Graph::EdgeNotFound
-      expect { undirected_graph.find_edge_by_labels! 'X', 'Y' }.to raise_error Graph::EdgeNotFound
+      expect { graph.find_edge_by_labels! 'X', 'Y' }.to raise_error Graph::EdgeNotFound
     end
   end
 
@@ -351,12 +304,12 @@ describe Math::Discrete::Graph do
 
   describe '#edge_labels' do
     let(:vertices) { Vertex::Set[*labels] }
-    let(:directed_edges) { Edge::Set::Directed[[*vertices]] }
-    let(:directed_graph) { Graph[vertices, directed_edges] }
+    let(:edges) { Edge::Set[[*vertices]] }
+    let(:graph) { Graph[vertices, edges] }
 
     it 'returns a set of all the edge labels' do
-      expect(directed_graph.edge_labels).to contain_exactly *directed_edges.map(&:labels)
-      expect(directed_graph.edge_labels).to be_an_instance_of Set
+      expect(graph.edge_labels).to contain_exactly *edges.map(&:labels)
+      expect(graph.edge_labels).to be_an_instance_of Set
     end
   end
 

--- a/spec/graph/graph_spec.rb
+++ b/spec/graph/graph_spec.rb
@@ -4,7 +4,23 @@ describe Math::Discrete::Graph do
   let(:labels) { [1, 2] }
 
   describe '#[]' do
-    skip
+    let(:graph) { Graph[[1, 2, 3], [[1, 2], [2, 3], [3, 1], [1, 3]]] }
+    let(:vertex_result) { graph[1] }
+    let(:edge_result) { graph[2, 3] }
+
+    it 'returns the vertex with the corresponding label' do
+      expect(vertex_result).to be_an_instance_of Vertex
+      expect(vertex_result.label).to be 1
+    end
+
+    it 'returns the edge with the corresponing labels' do
+      expect(edge_result).to be_an_instance_of Edge
+      expect(edge_result.labels).to contain_exactly 2, 3
+    end
+
+    it 'returns nil if no vertex or edge have the given labels' do
+      expect(graph['hello']).to be_nil
+    end
   end
 
   describe '#<<' do

--- a/spec/graph/graph_spec.rb
+++ b/spec/graph/graph_spec.rb
@@ -3,6 +3,61 @@ require 'spec_helper'
 describe Math::Discrete::Graph do
   let(:labels) { [1, 2] }
 
+  describe '#[]' do
+    skip
+  end
+
+  describe '#<<' do
+    context 'with a vertex' do
+      let(:graph) { Graph[] }
+      let(:vertex) { Vertex[labels.first] }
+
+      it 'adds the vertex to the vertex set' do
+        graph << vertex
+        expect(graph.vertex_set).to include vertex
+      end
+
+      it 'raises a TypeError if the input is not a Vertex' do
+        expect {
+          graph << 'This is not a vertex'
+        }.to raise_error TypeError
+      end
+
+      it 'raises a VertexNotUnique if the input is a vertex that is already in the vertex set' do
+        graph << vertex
+
+        expect {
+          graph << vertex
+        }.to raise_error Graph::VertexNotUnique
+      end
+    end
+
+    context 'with an edge' do
+      let(:vertices) { Vertex::Set[*labels] }
+      let(:graph) { Graph[vertices] }
+      let(:edge) { Edge[*vertices] }
+
+      it 'adds the edge to the edge set' do
+        graph << edge
+        expect(graph.edge_set).to include edge
+      end
+
+      it 'raises a EdgeNotUnique if the input is an edge that is already in the edge set' do
+        expect {
+          graph  << 'This is not an edge'
+        }.to raise_error TypeError
+      end
+
+      it 'raises a EdgeNotUnique if the input is a edge that is already in the edge set' do
+        graph << edge
+
+        expect {
+          graph << edge
+        }.to raise_error Graph::EdgeNotUnique
+      end
+    end
+  end
+
   describe '::[]' do
     let(:vertex_set) { Vertex::Set['A', 'B', 'C'] }
     let(:edge_set) do

--- a/spec/graph/path_spec.rb
+++ b/spec/graph/path_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Math::Discrete::Graph::Path do
   let(:vertices) { Vertex::Set[1,2,3,4] }
   let(:edges) do
-    Edge::Set::Directed[
+    Edge::Set[
       [vertices.entries[0], vertices.entries[1]],
       [vertices.entries[1], vertices.entries[2]],
       [vertices.entries[2], vertices.entries[3]]
@@ -13,7 +13,7 @@ describe Math::Discrete::Graph::Path do
 
   describe '::[]' do
     it 'raises an InvalidPath if the given edges do not make a continuous path' do
-      edges.add Edge::Directed[vertices.entries[2], vertices.entries[0]]
+      edges.add Edge[vertices.entries[2], vertices.entries[0]]
 
       expect { Graph::Path[*edges] }.to raise_error Graph::Path::InvalidPath
     end
@@ -26,7 +26,7 @@ describe Math::Discrete::Graph::Path do
 
   describe '#cyclical?' do
     it 'returns true if the path ends in the same vertex that it starts with' do
-      edges.add Edge::Directed[vertices.entries[3], vertices.entries[0]]
+      edges.add Edge[vertices.entries[3], vertices.entries[0]]
       cycle = Graph::Path[*edges]
 
       expect(cycle).to be_cyclical

--- a/spec/graph/path_spec.rb
+++ b/spec/graph/path_spec.rb
@@ -37,26 +37,17 @@ describe Math::Discrete::Graph::Path do
     end
   end
 
-  describe '#labels' do
-    let(:labels) { path.labels }
-
-    it 'returns a Set of edge labels' do
-      expect(labels).to be_an_instance_of Set
-      expect(labels).to contain_exactly [1,2], [2,3], [3,4]
-    end
-  end
-
-  describe '#vertices, #nodes' do
-    it 'returns a Set vertices along the path' do
+  describe '#edges' do
+    it 'returns a Set of edges along the path' do
       expect(path.vertices).to be_an_instance_of Set
       expect(path.vertices).to contain_exactly *vertices
     end
   end
 
-  describe '#length' do
-    it 'returns the number of edges along the path' do
-      expect(Graph::Path[].length).to be 0
-      expect(path.length).to be 3
+  describe '#vertices, #nodes' do
+    it 'returns a Set of vertices along the path' do
+      expect(path.vertices).to be_an_instance_of Set
+      expect(path.vertices).to contain_exactly *vertices
     end
   end
 end

--- a/spec/graph/properties_spec.rb
+++ b/spec/graph/properties_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Math::Discrete::Graph::Properties do
-  let(:directed_graph) { Graph[[1,2,3,4], [[1,2],[2,3],[3,1], [1,4], [4,2]]] }
+  let(:graph) { Graph[[1,2,3,4], [[1,2],[2,3],[3,1], [1,4], [4,2]]] }
   let(:complete_graph) { Graph[[*(1..5)], (1..5).to_a.permutation(2).to_a] }
   let(:even_cycle) { Graph[[*(1..10)], [*((1..10).each_cons(2).to_a << [10,1])]] }
   let(:odd_cycle) { Graph[[*(1..7)], [*((1..7).each_cons(2).to_a << [7,1])]] }
@@ -65,7 +65,7 @@ describe Math::Discrete::Graph::Properties do
     end
 
     it 'returns false if there is a vertex that is not adjacent to all other vertices in the graph' do
-      expect(directed_graph.satisfies? completeness).to be false
+      expect(graph.satisfies? completeness).to be false
     end
   end
 
@@ -77,7 +77,7 @@ describe Math::Discrete::Graph::Properties do
     end
 
     it 'returns false if there are two vertices that does not have the same number of adjacent vertices in the graph' do
-      expect(directed_graph.satisfies? regularity).to be false
+      expect(graph.satisfies? regularity).to be false
     end
   end
 end

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -40,7 +40,7 @@ describe Math::Discrete::Property do
     end
 
     it 'raises a TypeError if the satisfiability_test returns a non-Boolean result' do
-      graph = Graph.build
+      graph = Graph[]
 
       expect { bad_property.satisfied? graph }.to raise_error TypeError
     end


### PR DESCRIPTION
__Goal__
Accessing vertices and edges from `Graph` and `Path` objects was linear. I use hashes to make that access take constant-time.

I also remove the concept of directed and undirected graphs, everything is directed now, since it's the superset.